### PR TITLE
Client Coreboot Universal Payload boot failed in DEBUG mode.

### DIFF
--- a/MdeModulePkg/Library/LzmaCustomDecompressLib/LzmaCommonDecompressLib.inf
+++ b/MdeModulePkg/Library/LzmaCustomDecompressLib/LzmaCommonDecompressLib.inf
@@ -1,0 +1,53 @@
+## @file
+#  LzmaCustomDecompressLib produces LZMA custom decompression algorithm.
+#
+#  It is based on the LZMA SDK 19.00.
+#  LZMA SDK 19.00 was placed in the public domain on 2019-02-21.
+#  It was released on the http://www.7-zip.org/sdk.html website.
+#
+#  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = LzmaDecompressLib
+  MODULE_UNI_FILE                = LzmaDecompressLib.uni
+  FILE_GUID                      = f9fbdb5b-8110-4ebd-bc11-d3cddbcd95cf
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = NULL
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64 ARM
+#
+
+[Sources]
+  LzmaDecompress.c
+  Sdk/C/LzFind.c
+  Sdk/C/LzmaDec.c
+  Sdk/C/7zVersion.h
+  Sdk/C/CpuArch.h
+  Sdk/C/LzFind.h
+  Sdk/C/LzHash.h
+  Sdk/C/LzmaDec.h
+  Sdk/C/7zTypes.h
+  Sdk/C/Precomp.h
+  Sdk/C/Compiler.h
+  UefiLzma.h
+  LzmaDecompressLibInternal.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  BaseMemoryLib
+

--- a/UefiPayloadPkg/Include/Coreboot.h
+++ b/UefiPayloadPkg/Include/Coreboot.h
@@ -47,6 +47,11 @@
 #define IMD_ENTRY_MAGIC    (~0xC0389481)
 #define CBMEM_ENTRY_MAGIC  (~0xC0389479)
 
+struct imd_root_pointer {
+  UINT32    magic;
+  INT32     root_offset;
+};
+
 struct cbmem_entry {
   UINT32    magic;
   UINT32    start;
@@ -249,7 +254,80 @@ struct cb_cbmem_tab {
   UINT64    cbmem_tab;
 };
 
-/* Helpful macros */
+#define FMAP_STRLEN             32
+#define CBMEM_ID_IMD_SMALL      0x53a11439
+#define CBMEM_ID_FMAP           0x464d4150
+#define CBMEM_ID_CBFS_RO_MCACHE 0x524d5346
+#define CBMEM_ID_FSP_RUNTIME    0x52505346
+#define MCACHE_MAGIC_FILE       0x454c4946
+#define MCACHE_MAGIC_FULL       0x4c4c5546
+#define MCACHE_MAGIC_END        0x444e4524
+#define CBFS_METADATA_MAX_SIZE  256
+#define CBFS_UNIVERSAL_PAYLOAD  "img/UniversalPayload"
+#define CBFS_MCACHE_ALIGNMENT   sizeof (UINT32)
+
+#pragma pack(1)
+struct cbfs_file {
+  char magic[8];
+  UINT32 len;
+  UINT32 type;
+  UINT32 attributes_offset;
+  UINT32 offset;
+  char filename[0];
+} ;
+
+struct fmap_area {
+  UINT32 offset;            /* offset relative to base */
+  UINT32 size;              /* size in bytes */
+  UINT8  name[FMAP_STRLEN]; /* descriptive name */
+  UINT16 flags;             /* flags for this area */
+};
+
+struct fmap {
+  UINT8  signature[8];      /* "__FMAP__" (0x5F5F464D41505F5F) */
+  UINT8  ver_major;         /* major version */
+  UINT8  ver_minor;         /* minor version */
+  UINT64 base;              /* address of the firmware binary */
+  UINT32 size;              /* size of firmware binary in bytes */
+  UINT8  name[FMAP_STRLEN]; /* name of this firmware binary */
+  UINT16 nareas;            /* number of areas */
+  struct fmap_area areas[];
+};
+
+struct cbfs_payload_segment {
+  UINT32 type;
+  UINT32 compression;
+  UINT32 offset;
+  UINT64 load_addr;
+  UINT32 len;
+  UINT32 mem_len;
+};
+
+struct cbfs_payload {
+  struct cbfs_payload_segment segments;
+};
+#pragma pack()
+
+union cbfs_mdata {
+  struct cbfs_file h;
+  UINT8 raw[CBFS_METADATA_MAX_SIZE];
+};
+
+union mcache_entry {
+  union cbfs_mdata file;
+  struct {  /* These fields exactly overlap file.h.magic */
+    UINT32 magic;
+    UINT32 offset;
+  };
+};
+
+enum cbfs_payload_segment_type {
+  PAYLOAD_SEGMENT_CODE   = 0x434F4445,  /* BE: 'CODE' */
+  PAYLOAD_SEGMENT_DATA   = 0x44415441,  /* BE: 'DATA' */
+  PAYLOAD_SEGMENT_BSS    = 0x42535320,  /* BE: 'BSS ' */
+  PAYLOAD_SEGMENT_PARAMS = 0x50415241,  /* BE: 'PARA' */
+  PAYLOAD_SEGMENT_ENTRY  = 0x454E5452,  /* BE: 'ENTR' */
+};
 
 #define MEM_RANGE_COUNT(_rec) \
   (((_rec)->size - sizeof(*(_rec))) / sizeof((_rec)->map[0]))

--- a/UefiPayloadPkg/PayloadLoaderPeim/ElfLoaderLib.inf
+++ b/UefiPayloadPkg/PayloadLoaderPeim/ElfLoaderLib.inf
@@ -1,0 +1,45 @@
+## @file
+#  Produce LoadFile PPI for payload loading.
+#
+#  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = ElfLoaderLib
+  FILE_GUID                      = EC2CE04E-FCC5-4D4B-87F4-3E5DFF9FD592
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = NULL
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  ElfLib.h
+  ElfLib/ElfLibInternal.h
+  ElfLib/ElfCommon.h
+  ElfLib/Elf32.h
+  ElfLib/Elf64.h
+  ElfLib/ElfLibInternal.h
+  ElfLib/ElfLib.c
+  ElfLib/Elf32Lib.c
+  ElfLib/Elf64Lib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UefiPayloadPkg/UefiPayloadPkg.dec
+
+[LibraryClasses]
+  PcdLib
+  BaseMemoryLib
+  HobLib
+  BaseLib
+  DebugLib

--- a/UefiPayloadPkg/ShimLayer/HobIioUds.h
+++ b/UefiPayloadPkg/ShimLayer/HobIioUds.h
@@ -1,0 +1,239 @@
+/** @file
+
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __HOB_IIO_UDS_H__
+#define __HOB_IIO_UDS_H__
+
+#include <PiPei.h>
+
+#define IIO_UNIVERSAL_DATA_GUID { 0x7FF396A1, 0xEE7D, 0x431E, { 0xBA, 0x53, 0x8F, 0xCA, 0x12, 0x7C, 0x44, 0xC0 } }
+
+typedef enum {
+  TYPE_UBOX = 0,              // Stack/Tile with only Ubox device
+  TYPE_UBOX_IIO,              // DMI/PCIe Stack (Stack0) that hosts both IIO and Ubox devices (this is used in 14nm SOC)
+  TYPE_IIO,                   // PCIe/CXL/DMI stack
+  TYPE_MCP,
+  TYPE_FPGA,
+  TYPE_HFI,
+  TYPE_NAC,
+  TYPE_GRAPHICS,
+  TYPE_DINO,
+  TYPE_TSNO_DICH,
+  TYPE_DICH,
+  TYPE_TIP,
+  TYPE_RESERVED,
+  TYPE_DISABLED,              // This item must be prior to stack specific disable types
+  TYPE_UBOX_IIO_DIS,
+  TYPE_IIO_DIS,
+  TYPE_MCP_DIS,
+  TYPE_FPGA_DIS,
+  TYPE_HFI_DIS,
+  TYPE_NAC_DIS,
+  TYPE_GRAPHICS_DIS,
+  TYPE_DINO_DIS,
+  TYPE_RESERVED_DIS,
+  TYPE_TSNO_DICH_DIS,
+  TYEP_DICH_DIS,
+  TYPE_TIP_DIS,
+  TYPE_NONE
+} STACK_TYPE;
+
+
+#ifndef MAX_SOCKET
+#define MAX_SOCKET              2
+#endif
+
+#if (MAX_SOCKET == 1)
+  #define MAX_FW_KTI_PORTS     4    // Maximum KTI PORTS to be used in structure definition.
+#else
+  #define MAX_FW_KTI_PORTS     6    // Maximum KTI PORTS to be used in structure definition
+#endif //(MAX_SOCKET == 1)
+
+#define MAX_LOGIC_IIO_STACK          18
+
+#ifndef MAX_IIO_PCIROOTS_PER_STACK
+#define MAX_IIO_PCIROOTS_PER_STACK   3   // PCI roots that can be created for a stack
+#endif
+
+#define MAX_COMPUTE_DIE            3
+#define MAX_CHA_MAP                (2 * MAX_COMPUTE_DIE)  //for GNR & SRF only, each compute die has its own CAPID6 & CAPID7 (i.e. 2 CAPID registers)
+
+#ifndef MAX_MESSAGE_LENGTH
+#define MAX_MESSAGE_LENGTH  500
+#endif
+
+#pragma pack(1)
+
+typedef enum {
+  TYPE_SCF_BAR = 0,
+  TYPE_PCU_BAR,
+  TYPE_MEM_BAR0,
+  TYPE_MEM_BAR1,
+  TYPE_MEM_BAR2,
+  TYPE_MEM_BAR3,
+  TYPE_MEM_BAR4,
+  TYPE_MEM_BAR5,
+  TYPE_MEM_BAR6,
+  TYPE_MEM_BAR7,
+  TYPE_SBREG_BAR,
+  TYPE_MAX_MMIO_BAR
+} MMIO_BARS;
+
+typedef struct {
+  UINT8   Major;
+  UINT8   Minor;
+  UINT8   Revision;
+  UINT16  BuildNumber;
+} RC_VERSION;
+
+//--------------------------------------------------------------------------------------//
+// Structure definitions for Universal Data Store (UDS)
+//--------------------------------------------------------------------------------------//
+typedef struct {
+  UINT8                     Valid;         // TRUE, if the link is valid (i.e reached normal operation)
+  UINT8                     PeerSocId;     // Socket ID
+  UINT8                     PeerSocType;   // Socket Type (0 - CPU; 1 - IIO)
+  UINT8                     PeerPort;      // Port of the peer socket
+} QPI_PEER_DATA;
+
+typedef struct {
+  UINT8                     Valid;
+  UINT8                     PcieSegment;
+  UINT64                    SegMmcfgBase;
+  UINT32                    StackPresentBitmap;
+  UINT16                    Cxl1p1PresentBitmap; // Bitmap of stacks where CXL 1p1 is connected
+  UINT16                    CxlCapableBitmap;    // Bitmap of stacks capable of CXL
+  UINT8                     TotM3Kti;
+  UINT8                     TotCha;
+  UINT32                    ChaList[MAX_CHA_MAP];
+  UINT32                    SocId;
+  QPI_PEER_DATA             PeerInfo[MAX_FW_KTI_PORTS];    // QPI LEP info
+} QPI_CPU_DATA;
+
+typedef struct {
+  UINT8                     Valid;
+  UINT8                     SocId;
+  QPI_PEER_DATA             PeerInfo[MAX_SOCKET];    // QPI LEP info
+} QPI_IIO_DATA;
+
+/**
+ * PCI resources that establish one PCI hierarchy for PCI Enumerator.
+ */
+typedef struct {
+  UINT16                  UidType;               // Type of UID for this root bridge.
+  UINT8                   BusBase;               // Base of PCI bus numbers available for PCI devices
+  UINT8                   BusLimit;              // Limit of PCI bus numbers available for PCI devices
+  UINT16                  IoBase;                // Base of IO resources available for PCI devices
+  UINT16                  IoLimit;               // Limit of IO resources available for PCI devices
+  UINT32                  Mmio32Base;            // Base of low MMIO resources available for PCI devices
+  UINT32                  Mmio32Limit;           // Limit of low MMIO resources available for PCI devices
+  UINT64                  Mmio64Base;            // Base of high MMIO resources available for PCI devices
+  UINT64                  Mmio64Limit;           // Limit of high MMIO resources available for PCI devices
+} UDS_PCIROOT_RES;
+
+/**
+ * This structore keeps resources configured in Host I/O Processor (HIOP) for one stack.
+ * One HIOP may produce more than one PCI hierarchy, these are in PciRoot[] table.
+ */
+typedef struct {
+  UINT8                   Personality;
+  UINT8                   PciRootBridgeNum;      // Number of valid entries in PciRoot[] table
+  UINT8                   BusBase;               // Base of Bus configured for this stack
+  UINT8                   BusLimit;              // Limit of Bus configured for this stack
+  UINT16                  IoBase;                // Base of IO configured for this stack
+  UINT16                  IoLimit;               // Limit of IO configured for this stack
+  UINT32                  IoApicBase;
+  UINT32                  IoApicLimit;
+  UINT32                  Mmio32Base;            // Base of low MMIO configured for this stack in memory map
+  UINT32                  Mmio32Limit;           // Limit of low MMIO configured for this stack in memory map
+  UINT64                  Mmio64Base;            // Base of high MMIO configured for this stack in memory map
+  UINT64                  Mmio64Limit;           // Limit of high MMIO configured for this stack in memory map
+  UDS_PCIROOT_RES         PciRoot[MAX_IIO_PCIROOTS_PER_STACK];
+} UDS_STACK_RES;
+
+typedef struct {
+  UINT8                   Valid;
+  UINT8                   SocketID;            // Socket ID of the IIO (0..3)
+  UINT8                   BusBase;
+  UINT8                   BusLimit;
+  UINT16                  IoBase;
+  UINT16                  IoLimit;
+  UINT32                  IoApicBase;
+  UINT32                  IoApicLimit;
+  UINT32                  Mmio32Base;          // Base of low MMIO configured for this socket in memory map
+  UINT32                  Mmio32Limit;         // Limit of low MMIO configured for this socket in memory map
+  UINT64                  Mmio64Base;          // Base of high MMIO configured for this socket in memory map
+  UINT64                  Mmio64Limit;         // Limit of high MMIO configured for this socket in memory map
+  UDS_STACK_RES           StackRes[MAX_LOGIC_IIO_STACK];
+} UDS_SOCKET_RES;
+
+typedef struct {
+  UINT16                  PlatGlobalIoBase;       // Global IO Base
+  UINT16                  PlatGlobalIoLimit;      // Global IO Limit
+  UINT32                  PlatGlobalMmio32Base;   // Global Mmiol base
+  UINT32                  PlatGlobalMmio32Limit;  // Global Mmiol limit
+  UINT64                  PlatGlobalMmio64Base;   // Global Mmioh Base [43:0]
+  UINT64                  PlatGlobalMmio64Limit;  // Global Mmioh Limit [43:0]
+  QPI_CPU_DATA            CpuQpiInfo[MAX_SOCKET]; // QPI related info per CPU
+  QPI_IIO_DATA            IioQpiInfo[MAX_SOCKET]; // QPI related info per IIO
+  UINT32                  MemTsegSize;
+  UINT32                  MemIedSize;
+  UINT64                  PciExpressBase;         // PCI Config Space base address
+  UINT32                  PciExpressSize;         // PCI Config Space size
+  UINT32                  MemTolm;
+  UDS_SOCKET_RES          IIO_resource[MAX_SOCKET];
+  UINT8                   numofIIO;
+  UINT8                   MaxBusNumber;
+  UINT32                  packageBspApicID[MAX_SOCKET]; // This data array is valid only for SBSP, not for non-SBSP CPUs. <AS> for CpuSv
+  UINT16                  IoGranularity;
+  UINT32                  MmiolGranularity;
+  UINT64                  MmiohGranularity;
+  UINT8                   RemoteRequestThreshold;  //5370389
+  UINT32                  UboxMmioSize;
+  UINT32                  MaxAddressBits;
+} PLATFORM_DATA;
+
+typedef struct {
+    BOOLEAN                 FailFlag;
+    CHAR16                  Message[MAX_MESSAGE_LENGTH];
+} REBALANCE_FAIL_INFO;
+
+typedef struct {
+    UINT8                   CurrentUpiiLinkSpeed;    // Current programmed UPI Link speed (Slow/Full speed mode)
+    UINT8                   CurrentUpiLinkFrequency; // Current requested UPI Link frequency (in GT)
+    UINT8                   OutKtiCpuSktHotPlugEn;            // 0 - Disabled, 1 - Enabled for PM X2APIC
+    UINT32                  OutKtiPerLinkL1En[MAX_SOCKET];    // output kti link enabled status for PM
+    UINT8                   IsocEnable;
+    UINT32                  meRequestedSize;        // Size of the memory range requested by ME FW, in MB
+    UINT8                   DmiVc1;
+    UINT8                   DmiVcm;
+    UINT32                  CpuPCPSInfo;
+    UINT8                   cpuSubType;
+    UINT8                   SystemRasType;
+    UINT8                   numCpus;           // 1,..4. Total number of CPU packages installed and detected (1..4)by QPI RC
+    UINT16                  tolmLimit;
+    RC_VERSION              RcVersion;
+    UINT8                   bootMode;
+    UINT8                   OutClusterOnDieEn; // Whether RC enabled COD support
+    UINT8                   OutSncEn;
+    UINT8                   OutNumOfCluster;
+    UINT16                  LlcSizeReg;
+    UINT8                   IoDcMode;
+    UINT8                   BitsUsed;    //For 5 Level Paging
+    REBALANCE_FAIL_INFO     RebalanceFailInfo;
+} SYSTEM_STATUS;
+
+typedef struct {
+    PLATFORM_DATA           PlatformData;
+    SYSTEM_STATUS           SystemStatus;
+    UINT32                  OemValue;
+} IIO_UDS;
+
+#pragma pack()
+
+#endif  // _IIO_UNIVERSAL_DATA_HOB_H_

--- a/UefiPayloadPkg/ShimLayer/ShimLayer.c
+++ b/UefiPayloadPkg/ShimLayer/ShimLayer.c
@@ -1,0 +1,783 @@
+/** @file
+
+Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "ShimLayer.h"
+
+STATIC UINT32  mTopOfLowerUsableDram = 0;
+
+extern char  _binary_UniversalPayload_elf_start[];
+
+/**
+  Allocates one or more pages of type EfiBootServicesData.
+
+  Allocates the number of pages of MemoryType and returns a pointer to the
+  allocated buffer.  The buffer returned is aligned on a 4KB boundary.
+  If Pages is 0, then NULL is returned.
+  If there is not enough memory availble to satisfy the request, then NULL
+  is returned.
+
+  @param   Pages                 The number of 4 KB pages to allocate.
+  @return  A pointer to the allocated buffer or NULL if allocation fails.
+**/
+VOID *
+AllocatePages (
+  IN UINTN  Pages
+  )
+{
+  EFI_PEI_HOB_POINTERS        Hob;
+  EFI_PHYSICAL_ADDRESS        Offset;
+  EFI_HOB_HANDOFF_INFO_TABLE  *HobTable;
+
+  Hob.Raw  = GetHobList ();
+  HobTable = Hob.HandoffInformationTable;
+
+  if (Pages == 0) {
+    return NULL;
+  }
+
+  // Make sure allocation address is page alligned.
+  Offset = HobTable->EfiFreeMemoryTop & EFI_PAGE_MASK;
+  if (Offset != 0) {
+    HobTable->EfiFreeMemoryTop -= Offset;
+  }
+
+  //
+  // Check available memory for the allocation
+  //
+  if (HobTable->EfiFreeMemoryTop - ((Pages * EFI_PAGE_SIZE) + sizeof (EFI_HOB_MEMORY_ALLOCATION)) < HobTable->EfiFreeMemoryBottom) {
+    return NULL;
+  }
+
+  HobTable->EfiFreeMemoryTop -= Pages * EFI_PAGE_SIZE;
+  BuildMemoryAllocationHob (HobTable->EfiFreeMemoryTop, Pages * EFI_PAGE_SIZE, EfiBootServicesData);
+
+  return (VOID *)(UINTN)HobTable->EfiFreeMemoryTop;
+}
+
+/**
+  Acquire the coreboot memory table with the given table id
+
+  @param  TableId            Table id to be searched
+  @param  MemTable           Pointer to the base address of the memory table
+  @param  MemTableSize       Pointer to the size of the memory table
+
+  @retval RETURN_SUCCESS     Successfully find out the memory table.
+  @retval RETURN_INVALID_PARAMETER  Invalid input parameters.
+  @retval RETURN_NOT_FOUND   Failed to find the memory table.
+
+**/
+RETURN_STATUS
+ParseCbmemInfo (
+  IN  UINT32  TableId,
+  OUT VOID    **MemTable,
+  OUT UINT32  *MemTableSize
+  )
+{
+  EFI_STATUS               Status;
+  CB_MEMORY                *Rec;
+  struct cb_memory_range   *Range;
+  UINT64                   Start;
+  UINT64                   Size;
+  UINTN                    Index;
+  struct cbmem_root        *CbMemLgRoot;
+  VOID                     *CbMemSmRoot;
+  VOID                     *CbMemSmRootTable;
+  UINT32                   SmRootTableSize;
+  struct imd_root_pointer  *SmRootPointer;
+
+  if (MemTable == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  *MemTable = NULL;
+  Status    = RETURN_NOT_FOUND;
+
+  //
+  // Get the coreboot memory table
+  //
+  Rec = (CB_MEMORY *)FindCbTag (CB_TAG_MEMORY);
+  if (Rec == NULL) {
+    return Status;
+  }
+
+  for (Index = 0; Index < MEM_RANGE_COUNT (Rec); Index++) {
+    Range = MEM_RANGE_PTR (Rec, Index);
+    Start = cb_unpack64 (Range->start);
+    Size  = cb_unpack64 (Range->size);
+
+    if ((Range->type == CB_MEM_TABLE) && (Start > 0x1000)) {
+      CbMemLgRoot = (struct  cbmem_root *)(UINTN)(Start + Size - DYN_CBMEM_ALIGN_SIZE);
+      Status      = FindCbMemTable (CbMemLgRoot, TableId, MemTable, MemTableSize);
+      if (!EFI_ERROR (Status)) {
+        break;
+      } else {
+        /* Try to locate small root table and find the target CBMEM entry in small root table */
+        Status        = FindCbMemTable (CbMemLgRoot, CBMEM_ID_IMD_SMALL, &CbMemSmRootTable, &SmRootTableSize);
+        SmRootPointer = (struct imd_root_pointer *)(UINTN)((UINTN)CbMemSmRootTable + SmRootTableSize - sizeof (struct imd_root_pointer));
+        CbMemSmRoot   = (struct cbmem_root *)(UINTN)(SmRootPointer->root_offset + (UINTN)SmRootPointer);
+        if (!EFI_ERROR (Status)) {
+          Status = FindCbMemTable ((struct cbmem_root *)CbMemSmRoot, TableId, MemTable, MemTableSize);
+          if (!EFI_ERROR (Status)) {
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  return Status;
+}
+
+/**
+   Callback function to find TOLUD (Top of Lower Usable DRAM)
+
+   Estimate where TOLUD (Top of Lower Usable DRAM) resides. The exact position
+   would require platform specific code.
+
+   @param MemoryMapEntry         Memory map entry info got from bootloader.
+   @param Params                 Not used for now.
+
+  @retval EFI_SUCCESS            Successfully updated mTopOfLowerUsableDram.
+**/
+EFI_STATUS
+FindToludCallback (
+  IN MEMORY_MAP_ENTRY  *MemoryMapEntry,
+  IN VOID              *Params
+  )
+{
+  //
+  // This code assumes that the memory map on this x86 machine below 4GiB is continous
+  // until TOLUD. In addition it assumes that the bootloader provided memory tables have
+  // no "holes" and thus the first memory range not covered by e820 marks the end of
+  // usable DRAM. In addition it's assumed that every reserved memory region touching
+  // usable RAM is also covering DRAM, everything else that is marked reserved thus must be
+  // MMIO not detectable by bootloader/OS
+  //
+
+  //
+  // Skip memory types not RAM or reserved
+  //
+  if ((MemoryMapEntry->Type == E820_UNUSABLE) || (MemoryMapEntry->Type == E820_DISABLED) ||
+      (MemoryMapEntry->Type == E820_PMEM))
+  {
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Skip resources above 4GiB
+  //
+  if ((MemoryMapEntry->Base + MemoryMapEntry->Size) > 0x100000000ULL) {
+    return EFI_SUCCESS;
+  }
+
+  if ((MemoryMapEntry->Type == E820_RAM) || (MemoryMapEntry->Type == E820_ACPI) ||
+      (MemoryMapEntry->Type == E820_NVS))
+  {
+    //
+    // It's usable DRAM. Update TOLUD.
+    //
+    if (mTopOfLowerUsableDram < (MemoryMapEntry->Base + MemoryMapEntry->Size)) {
+      mTopOfLowerUsableDram = (UINT32)(MemoryMapEntry->Base + MemoryMapEntry->Size);
+    }
+  } else {
+    //
+    // It might be 'reserved DRAM' or 'MMIO'.
+    //
+    // If it touches usable DRAM at Base assume it's DRAM as well,
+    // as it could be bootloader installed tables, TSEG, GTT, ...
+    //
+    if (mTopOfLowerUsableDram == MemoryMapEntry->Base) {
+      mTopOfLowerUsableDram = (UINT32)(MemoryMapEntry->Base + MemoryMapEntry->Size);
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+   Callback function to build resource descriptor HOB
+
+   This function build a HOB based on the memory map entry info.
+   Only add EFI_RESOURCE_SYSTEM_MEMORY.
+
+   @param MemoryMapEntry         Memory map entry info got from bootloader.
+   @param Params                 Not used for now.
+
+  @retval RETURN_SUCCESS        Successfully build a HOB.
+**/
+EFI_STATUS
+MemInfoCallback (
+  IN MEMORY_MAP_ENTRY  *MemoryMapEntry,
+  IN VOID              *Params
+  )
+{
+  EFI_PHYSICAL_ADDRESS         Base;
+  EFI_RESOURCE_TYPE            Type;
+  UINT64                       Size;
+  EFI_RESOURCE_ATTRIBUTE_TYPE  Attribue;
+
+  //
+  // Skip everything not known to be usable DRAM.
+  // It will be added later.
+  //
+  if ((MemoryMapEntry->Type != E820_RAM) && (MemoryMapEntry->Type != E820_ACPI) &&
+      (MemoryMapEntry->Type != E820_NVS))
+  {
+    return RETURN_SUCCESS;
+  }
+
+  Type = EFI_RESOURCE_SYSTEM_MEMORY;
+  Base = MemoryMapEntry->Base;
+  Size = MemoryMapEntry->Size;
+
+  Attribue = EFI_RESOURCE_ATTRIBUTE_PRESENT |
+             EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
+             EFI_RESOURCE_ATTRIBUTE_TESTED |
+             EFI_RESOURCE_ATTRIBUTE_UNCACHEABLE |
+             EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE |
+             EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE |
+             EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE;
+
+  BuildResourceDescriptorHob (Type, Attribue, (EFI_PHYSICAL_ADDRESS)Base, Size);
+  DEBUG ((DEBUG_INFO, "buildhob: base = 0x%lx, size = 0x%lx, type = 0x%x\n", Base, Size, Type));
+
+  if (MemoryMapEntry->Type == E820_ACPI) {
+    BuildMemoryAllocationHob (Base, Size, EfiACPIReclaimMemory);
+  } else if (MemoryMapEntry->Type == E820_NVS) {
+    BuildMemoryAllocationHob (Base, Size, EfiACPIMemoryNVS);
+  }
+
+  return RETURN_SUCCESS;
+}
+
+/**
+   Callback function to build resource descriptor HOB
+
+   This function build a HOB based on the memory map entry info.
+   It creates only EFI_RESOURCE_MEMORY_MAPPED_IO and EFI_RESOURCE_MEMORY_RESERVED
+   resources.
+
+   @param MemoryMapEntry         Memory map entry info got from bootloader.
+   @param Params                 A pointer to ACPI_BOARD_INFO.
+
+  @retval EFI_SUCCESS            Successfully build a HOB.
+  @retval EFI_INVALID_PARAMETER  Invalid parameter provided.
+**/
+EFI_STATUS
+MemInfoCallbackMmio (
+  IN MEMORY_MAP_ENTRY  *MemoryMapEntry,
+  IN VOID              *Params
+  )
+{
+  EFI_PHYSICAL_ADDRESS         Base;
+  EFI_RESOURCE_TYPE            Type;
+  UINT64                       Size;
+  EFI_RESOURCE_ATTRIBUTE_TYPE  Attribue;
+
+  //
+  // Skip types already handled in MemInfoCallback
+  //
+  if ((MemoryMapEntry->Type == E820_RAM) || (MemoryMapEntry->Type == E820_ACPI)) {
+    return EFI_SUCCESS;
+  }
+
+  if (MemoryMapEntry->Base < mTopOfLowerUsableDram) {
+    //
+    // It's in DRAM and thus must be reserved
+    //
+    Type = EFI_RESOURCE_MEMORY_RESERVED;
+  } else if ((MemoryMapEntry->Base < 0x100000000ULL) && (MemoryMapEntry->Base >= mTopOfLowerUsableDram)) {
+    //
+    // It's not in DRAM, must be MMIO
+    //
+    Type = EFI_RESOURCE_MEMORY_MAPPED_IO;
+  } else {
+    Type = EFI_RESOURCE_MEMORY_RESERVED;
+  }
+
+  Base = MemoryMapEntry->Base;
+  Size = MemoryMapEntry->Size;
+
+  Attribue = EFI_RESOURCE_ATTRIBUTE_PRESENT |
+             EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
+             EFI_RESOURCE_ATTRIBUTE_TESTED |
+             EFI_RESOURCE_ATTRIBUTE_UNCACHEABLE |
+             EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE |
+             EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE |
+             EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE;
+
+  BuildResourceDescriptorHob (Type, Attribue, (EFI_PHYSICAL_ADDRESS)Base, Size);
+  DEBUG ((DEBUG_INFO, "buildhob: base = 0x%lx, size = 0x%lx, type = 0x%x\n", Base, Size, Type));
+
+  if ((MemoryMapEntry->Type == E820_UNUSABLE) ||
+      (MemoryMapEntry->Type == E820_DISABLED))
+  {
+    BuildMemoryAllocationHob (Base, Size, EfiUnusableMemory);
+  } else if (MemoryMapEntry->Type == E820_PMEM) {
+    BuildMemoryAllocationHob (Base, Size, EfiPersistentMemory);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Parse and handle the misc info provided by bootloader
+
+  @retval RETURN_SUCCESS           The misc information was parsed successfully.
+  @retval RETURN_NOT_FOUND         Could not find required misc info.
+  @retval RETURN_OUT_OF_RESOURCES  Insufficant memory space.
+
+**/
+RETURN_STATUS
+EFIAPI
+ParseRootBridgeInfo (
+  OUT UNIVERSAL_PAYLOAD_PCI_ROOT_BRIDGE  *PciRootBridge,
+  OUT UINT32                             *PciRootBridgeCount
+  )
+{
+  EFI_STATUS         Status;
+  UINTN              *FspHobListAddr;
+  UINT32             HobLength;
+  EFI_HOB_GUID_TYPE  *GuidHob;
+  IIO_UDS            *IioUdsHob;
+  EFI_GUID           UniversalDataGuid = IIO_UNIVERSAL_DATA_GUID;
+  UINT32             Index;
+  UINT32             Count = 0;
+  UDS_STACK_RES      *StackRes;
+  UINT32             IIONum;
+  UINT32             PciRootIndex;
+
+  Status = ParseCbmemInfo (CBMEM_ID_FSP_RUNTIME, (VOID *)&FspHobListAddr, &HobLength);
+  DEBUG ((DEBUG_INFO, "Find FspHosList at 0x%x\n", *FspHobListAddr));
+  if (EFI_ERROR (Status)) {
+    return EFI_NOT_FOUND;
+  }
+
+  GuidHob = GetNextGuidHob (&UniversalDataGuid, (VOID *)(*FspHobListAddr));
+  if (GuidHob != NULL) {
+    IioUdsHob = (IIO_UDS *)GET_GUID_HOB_DATA (GuidHob);
+    for (IIONum = 0; IIONum <= IioUdsHob->PlatformData.numofIIO; IIONum++) {
+      for (Index = 0; Index < MAX_LOGIC_IIO_STACK; Index++) {
+        StackRes = &IioUdsHob->PlatformData.IIO_resource[IIONum].StackRes[Index];
+        // Payload only needs to handle the TYPE_IIO type stack info
+        if ((StackRes->BusBase <= StackRes->BusLimit) && (StackRes->Personality == TYPE_IIO)) {
+          for (PciRootIndex = 0; PciRootIndex < MAX_IIO_PCIROOTS_PER_STACK; PciRootIndex++) {
+            if (StackRes->PciRoot[PciRootIndex].BusBase != StackRes->BusBase) {
+              continue;
+            }
+
+            DEBUG ((DEBUG_INFO, "============================================================================\n"));
+            DEBUG ((DEBUG_INFO, "StackRes->PciRoot[PciRootIndex].BusBase    : %x\n", StackRes->PciRoot[PciRootIndex].BusBase));
+            DEBUG ((DEBUG_INFO, "StackRes->PciRoot[PciRootIndex].BusLimit   : %x\n", StackRes->PciRoot[PciRootIndex].BusLimit));
+            DEBUG ((DEBUG_INFO, "StackRes->PciRoot[PciRootIndex].IoBase     : %x\n", StackRes->PciRoot[PciRootIndex].IoBase));
+            DEBUG ((DEBUG_INFO, "StackRes->PciRoot[PciRootIndex].IoLimit    : %x\n", StackRes->PciRoot[PciRootIndex].IoLimit));
+            DEBUG ((DEBUG_INFO, "StackRes->PciRoot[PciRootIndex].Mmio32Base : %x\n", StackRes->PciRoot[PciRootIndex].Mmio32Base));
+            DEBUG ((DEBUG_INFO, "StackRes->PciRoot[PciRootIndex].Mmio32Limit: %x\n", StackRes->PciRoot[PciRootIndex].Mmio32Limit));
+            DEBUG ((DEBUG_INFO, "StackRes->PciRoot[PciRootIndex].Mmio64Base : %x\n", StackRes->PciRoot[PciRootIndex].Mmio64Base));
+            DEBUG ((DEBUG_INFO, "StackRes->PciRoot[PciRootIndex].Mmio64Limit: %x\n", StackRes->PciRoot[PciRootIndex].Mmio64Limit));
+            PciRootBridge[Count].Segment                 = IioUdsHob->PlatformData.CpuQpiInfo[IIONum].PcieSegment;
+            PciRootBridge[Count].Supports                = EFI_PCI_ATTRIBUTE_IDE_PRIMARY_IO | EFI_PCI_ATTRIBUTE_IDE_SECONDARY_IO | EFI_PCI_ATTRIBUTE_ISA_IO_16 | EFI_PCI_ATTRIBUTE_VGA_PALETTE_IO_16 | EFI_PCI_ATTRIBUTE_VGA_MEMORY | EFI_PCI_ATTRIBUTE_VGA_IO_16;
+            PciRootBridge[Count].Attributes              = 0;
+            PciRootBridge[Count].DmaAbove4G              = FALSE;
+            PciRootBridge[Count].NoExtendedConfigSpace   = FALSE;
+            PciRootBridge[Count].AllocationAttributes    = EFI_PCI_HOST_BRIDGE_COMBINE_MEM_PMEM | EFI_PCI_HOST_BRIDGE_MEM64_DECODE;
+            PciRootBridge[Count].Bus.Base                = StackRes->PciRoot[PciRootIndex].BusBase;
+            PciRootBridge[Count].Bus.Limit               = StackRes->PciRoot[PciRootIndex].BusLimit;
+            PciRootBridge[Count].Bus.Translation         = 0;
+            PciRootBridge[Count].Io.Base                 = StackRes->PciRoot[PciRootIndex].IoBase;
+            PciRootBridge[Count].Io.Limit                = StackRes->PciRoot[PciRootIndex].IoLimit;
+            PciRootBridge[Count].Io.Translation          = 0;
+            PciRootBridge[Count].Mem.Base                = StackRes->PciRoot[PciRootIndex].Mmio32Base;
+            PciRootBridge[Count].Mem.Limit               = StackRes->PciRoot[PciRootIndex].Mmio32Limit;
+            PciRootBridge[Count].Mem.Translation         = 0;
+            PciRootBridge[Count].MemAbove4G.Base         = StackRes->PciRoot[PciRootIndex].Mmio64Base;
+            PciRootBridge[Count].MemAbove4G.Limit        = StackRes->PciRoot[PciRootIndex].Mmio64Limit;
+            PciRootBridge[Count].MemAbove4G.Translation  = 0;
+            PciRootBridge[Count].PMem.Base               = 0xFFFFFFFFFFFFFFFF;
+            PciRootBridge[Count].PMem.Limit              = 0;
+            PciRootBridge[Count].PMem.Translation        = 0;
+            PciRootBridge[Count].PMemAbove4G.Base        = 0xFFFFFFFFFFFFFFFF;
+            PciRootBridge[Count].PMemAbove4G.Limit       = 0;
+            PciRootBridge[Count].PMemAbove4G.Translation = 0;
+            PciRootBridge[Count].HID                     = EISA_PNP_ID (0x0A03);
+            PciRootBridge[Count].UID                     = Count;
+            Count++;
+          }
+        }
+      }
+    }
+  }
+
+  *PciRootBridgeCount = Count;
+
+  return RETURN_SUCCESS;
+}
+
+/**
+  It will build HOBs based on information from bootloaders.
+
+  @retval EFI_SUCCESS        If it completed successfully.
+  @retval Others             If it failed to build required HOBs.
+**/
+EFI_STATUS
+BuildHobFromBl (
+  VOID
+  )
+{
+  EFI_STATUS                          Status;
+  EFI_PEI_GRAPHICS_INFO_HOB           GfxInfo;
+  EFI_PEI_GRAPHICS_INFO_HOB           *NewGfxInfo;
+  EFI_PEI_GRAPHICS_DEVICE_INFO_HOB    GfxDeviceInfo;
+  EFI_PEI_GRAPHICS_DEVICE_INFO_HOB    *NewGfxDeviceInfo;
+  UNIVERSAL_PAYLOAD_SMBIOS_TABLE      *SmBiosTableHob;
+  UNIVERSAL_PAYLOAD_ACPI_TABLE        *AcpiTableHob;
+  UNIVERSAL_PAYLOAD_PCI_ROOT_BRIDGE   PciRootBridge[84];
+  UINT32                              PciRootBridgeCount;
+  UNIVERSAL_PAYLOAD_PCI_ROOT_BRIDGES  *NewPciRootBridgeInfo;
+  UINT32                              Length;
+
+  //
+  // First find TOLUD
+  //
+  DEBUG ((DEBUG_INFO, "Guessing Top of Lower Usable DRAM:\n"));
+  Status = ParseMemoryInfo (FindToludCallback, NULL);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  DEBUG ((DEBUG_INFO, "Assuming TOLUD = 0x%x\n", mTopOfLowerUsableDram));
+
+  //
+  // Parse memory info and build memory HOBs for Usable RAM
+  //
+  DEBUG ((DEBUG_INFO, "Building ResourceDescriptorHobs for usable memory:\n"));
+  Status = ParseMemoryInfo (MemInfoCallback, NULL);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Create guid hob for frame buffer information
+  //
+  Status = ParseGfxInfo (&GfxInfo);
+  if (!EFI_ERROR (Status)) {
+    NewGfxInfo = BuildGuidHob (&gEfiGraphicsInfoHobGuid, sizeof (GfxInfo));
+    ASSERT (NewGfxInfo != NULL);
+    CopyMem (NewGfxInfo, &GfxInfo, sizeof (GfxInfo));
+    DEBUG ((DEBUG_INFO, "Created graphics info hob\n"));
+  }
+
+  Status = ParseGfxDeviceInfo (&GfxDeviceInfo);
+  if (!EFI_ERROR (Status)) {
+    NewGfxDeviceInfo = BuildGuidHob (&gEfiGraphicsDeviceInfoHobGuid, sizeof (GfxDeviceInfo));
+    ASSERT (NewGfxDeviceInfo != NULL);
+    CopyMem (NewGfxDeviceInfo, &GfxDeviceInfo, sizeof (GfxDeviceInfo));
+    DEBUG ((DEBUG_INFO, "Created graphics device info hob\n"));
+  }
+
+  //
+  // Creat SmBios table Hob
+  //
+  SmBiosTableHob = BuildGuidHob (&gUniversalPayloadSmbiosTableGuid, sizeof (UNIVERSAL_PAYLOAD_SMBIOS_TABLE));
+  ASSERT (SmBiosTableHob != NULL);
+  SmBiosTableHob->Header.Revision = UNIVERSAL_PAYLOAD_SMBIOS_TABLE_REVISION;
+  SmBiosTableHob->Header.Length   = sizeof (UNIVERSAL_PAYLOAD_SMBIOS_TABLE);
+  DEBUG ((DEBUG_INFO, "Create smbios table gUniversalPayloadSmbiosTableGuid guid hob\n"));
+  Status = ParseSmbiosTable (SmBiosTableHob);
+  if (!EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_INFO, "Detected Smbios Table at 0x%lx\n", SmBiosTableHob->SmBiosEntryPoint));
+  }
+
+  //
+  // Creat ACPI table Hob
+  //
+  AcpiTableHob = BuildGuidHob (&gUniversalPayloadAcpiTableGuid, sizeof (UNIVERSAL_PAYLOAD_ACPI_TABLE));
+  ASSERT (AcpiTableHob != NULL);
+  AcpiTableHob->Header.Revision = UNIVERSAL_PAYLOAD_ACPI_TABLE_REVISION;
+  AcpiTableHob->Header.Length   = sizeof (UNIVERSAL_PAYLOAD_ACPI_TABLE);
+  DEBUG ((DEBUG_INFO, "Create ACPI table gUniversalPayloadAcpiTableGuid guid hob\n"));
+  Status = ParseAcpiTableInfo (AcpiTableHob);
+  if (!EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_INFO, "Detected ACPI Table at 0x%lx\n", AcpiTableHob->Rsdp));
+  }
+
+  //
+  // Creat PciRootBridge Hob
+  //
+  ZeroMem (PciRootBridge, sizeof (PciRootBridge));
+  Status = ParseRootBridgeInfo (&PciRootBridge[0], &PciRootBridgeCount);
+  if (!EFI_ERROR (Status)) {
+    Length               = PciRootBridgeCount * sizeof (UNIVERSAL_PAYLOAD_PCI_ROOT_BRIDGE);
+    NewPciRootBridgeInfo = BuildGuidHob (&gUniversalPayloadPciRootBridgeInfoGuid, sizeof (UNIVERSAL_PAYLOAD_PCI_ROOT_BRIDGES) + Length);
+    ASSERT (NewPciRootBridgeInfo != NULL);
+
+    NewPciRootBridgeInfo->Count            = PciRootBridgeCount;
+    NewPciRootBridgeInfo->Header.Length    = sizeof (UNIVERSAL_PAYLOAD_PCI_ROOT_BRIDGES) + Length;
+    NewPciRootBridgeInfo->Header.Revision  = UNIVERSAL_PAYLOAD_PCI_ROOT_BRIDGES_REVISION;
+    NewPciRootBridgeInfo->ResourceAssigned = TRUE;
+
+    CopyMem (&(NewPciRootBridgeInfo->RootBridge[0]), &PciRootBridge, Length);
+    DEBUG ((DEBUG_INFO, "Created PCI root bridge info hob\n"));
+  }
+
+  //
+  // Parse memory info and build memory HOBs for reserved DRAM and MMIO
+  //
+  DEBUG ((DEBUG_INFO, "Building ResourceDescriptorHobs for reserved memory:\n"));
+  Status = ParseMemoryInfo (MemInfoCallbackMmio, NULL);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This function will build some generic HOBs that doesn't depend on information from bootloaders.
+
+**/
+VOID
+BuildGenericHob (
+  VOID
+  )
+{
+  UINT32                       RegEax;
+  UINT8                        PhysicalAddressBits;
+  EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceAttribute;
+
+  // Memory allocation hob for the Shim Layer
+  BuildMemoryAllocationHob (PcdGet32 (PcdPayloadFdMemBase), PcdGet32 (PcdPayloadFdMemSize), EfiBootServicesData);
+
+  //
+  // Build CPU memory space and IO space hob
+  //
+  AsmCpuid (0x80000000, &RegEax, NULL, NULL, NULL);
+  if (RegEax >= 0x80000008) {
+    AsmCpuid (0x80000008, &RegEax, NULL, NULL, NULL);
+    PhysicalAddressBits = (UINT8)RegEax;
+  } else {
+    PhysicalAddressBits = 36;
+  }
+
+  BuildCpuHob (PhysicalAddressBits, 16);
+
+  //
+  // Report Local APIC range, cause sbl HOB to be NULL, comment now
+  //
+  ResourceAttribute = (
+                       EFI_RESOURCE_ATTRIBUTE_PRESENT |
+                       EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
+                       EFI_RESOURCE_ATTRIBUTE_UNCACHEABLE |
+                       EFI_RESOURCE_ATTRIBUTE_TESTED
+                       );
+  BuildResourceDescriptorHob (EFI_RESOURCE_MEMORY_MAPPED_IO, ResourceAttribute, 0xFEC80000, SIZE_512KB);
+  BuildMemoryAllocationHob (0xFEC80000, SIZE_512KB, EfiMemoryMappedIO);
+}
+
+EFI_STATUS
+ConvertCbmemToHob (
+  VOID
+  )
+{
+  UINTN                               MemBase;
+  UINTN                               HobMemBase;
+  UINTN                               HobMemTop;
+  EFI_STATUS                          Status;
+  SERIAL_PORT_INFO                    SerialPortInfo;
+  UNIVERSAL_PAYLOAD_SERIAL_PORT_INFO  *UniversalSerialPort;
+
+  MemBase    = PcdGet32 (PcdPayloadFdMemBase);
+  HobMemBase = ALIGN_VALUE (MemBase + PcdGet32 (PcdPayloadFdMemSize), SIZE_1MB);
+  HobMemTop  = HobMemBase + PcdGet32 (PcdSystemMemoryUefiRegionSize);
+  HobConstructor ((VOID *)MemBase, (VOID *)HobMemTop, (VOID *)HobMemBase, (VOID *)HobMemTop);
+
+  Status = ParseSerialInfo (&SerialPortInfo);
+  if (!EFI_ERROR (Status)) {
+    UniversalSerialPort = BuildGuidHob (&gUniversalPayloadSerialPortInfoGuid, sizeof (UNIVERSAL_PAYLOAD_SERIAL_PORT_INFO));
+    ASSERT (UniversalSerialPort != NULL);
+    UniversalSerialPort->Header.Revision = UNIVERSAL_PAYLOAD_SERIAL_PORT_INFO_REVISION;
+    UniversalSerialPort->Header.Length   = sizeof (UNIVERSAL_PAYLOAD_SERIAL_PORT_INFO);
+    UniversalSerialPort->UseMmio         = (SerialPortInfo.Type == 1) ? FALSE : TRUE;
+    UniversalSerialPort->RegisterBase    = SerialPortInfo.BaseAddr;
+    UniversalSerialPort->BaudRate        = SerialPortInfo.Baud;
+    UniversalSerialPort->RegisterStride  = (UINT8)SerialPortInfo.RegWidth;
+  }
+
+  ProcessLibraryConstructorList ();
+  DEBUG ((DEBUG_INFO, "sizeof(UINTN) = 0x%x\n", sizeof (UINTN)));
+  Status = BuildHobFromBl ();
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "BuildHobFromBl Status = %r\n", Status));
+    return Status;
+  }
+
+  BuildGenericHob ();
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+LoadPayload (
+  OUT    EFI_PHYSICAL_ADDRESS  *ImageAddressArg   OPTIONAL,
+  OUT    UINT64                *ImageSizeArg,
+  OUT    PHYSICAL_ADDRESS      *UniversalPayloadEntry
+  )
+{
+  EFI_STATUS                    Status;
+  UINT32                        Index;
+  UINT16                        ExtraDataIndex;
+  CHAR8                         *SectionName;
+  UINTN                         Offset;
+  UINTN                         Size;
+  UINTN                         Length;
+  UINT32                        ExtraDataCount;
+  ELF_IMAGE_CONTEXT             Context;
+  UNIVERSAL_PAYLOAD_EXTRA_DATA  *ExtraData;
+
+  Status = ParseElfImage (_binary_UniversalPayload_elf_start, &Context);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  DEBUG ((
+    DEBUG_INFO,
+    "Payload File Size: 0x%08X, Mem Size: 0x%08x, Reload: %d\n",
+    Context.FileSize,
+    Context.ImageSize,
+    Context.ReloadRequired
+    ));
+
+  //
+  // Get UNIVERSAL_PAYLOAD_INFO_HEADER and number of additional PLD sections.
+  //
+
+  ExtraDataCount = 0;
+  for (Index = 0; Index < Context.ShNum; Index++) {
+    Status = GetElfSectionName (&Context, Index, &SectionName);
+    if (EFI_ERROR (Status)) {
+      continue;
+    }
+
+    DEBUG ((DEBUG_INFO, "Payload Section[%d]: %a\n", Index, SectionName));
+    if (AsciiStrnCmp (SectionName, UNIVERSAL_PAYLOAD_EXTRA_SEC_NAME_PREFIX, UNIVERSAL_PAYLOAD_EXTRA_SEC_NAME_PREFIX_LENGTH) == 0) {
+      Status = GetElfSectionPos (&Context, Index, &Offset, &Size);
+      if (!EFI_ERROR (Status)) {
+        ExtraDataCount++;
+      }
+    }
+  }
+
+  //
+  // Report the additional PLD sections through HOB.
+  //
+  Length    = sizeof (UNIVERSAL_PAYLOAD_EXTRA_DATA) + ExtraDataCount * sizeof (UNIVERSAL_PAYLOAD_EXTRA_DATA_ENTRY);
+  ExtraData = BuildGuidHob (
+                &gUniversalPayloadExtraDataGuid,
+                Length
+                );
+  ExtraData->Count           = ExtraDataCount;
+  ExtraData->Header.Revision = UNIVERSAL_PAYLOAD_EXTRA_DATA_REVISION;
+  ExtraData->Header.Length   = (UINT16)Length;
+  if (ExtraDataCount != 0) {
+    for (ExtraDataIndex = 0, Index = 0; Index < Context.ShNum; Index++) {
+      Status = GetElfSectionName (&Context, Index, &SectionName);
+      if (EFI_ERROR (Status)) {
+        continue;
+      }
+
+      if (AsciiStrnCmp (SectionName, UNIVERSAL_PAYLOAD_EXTRA_SEC_NAME_PREFIX, UNIVERSAL_PAYLOAD_EXTRA_SEC_NAME_PREFIX_LENGTH) == 0) {
+        Status = GetElfSectionPos (&Context, Index, &Offset, &Size);
+        if (!EFI_ERROR (Status)) {
+          ASSERT (ExtraDataIndex < ExtraDataCount);
+          AsciiStrCpyS (
+            ExtraData->Entry[ExtraDataIndex].Identifier,
+            sizeof (ExtraData->Entry[ExtraDataIndex].Identifier),
+            SectionName + UNIVERSAL_PAYLOAD_EXTRA_SEC_NAME_PREFIX_LENGTH
+            );
+          ExtraData->Entry[ExtraDataIndex].Base = (UINTN)(Context.FileBase + Offset);
+          ExtraData->Entry[ExtraDataIndex].Size = Size;
+          ExtraDataIndex++;
+        }
+      }
+    }
+  }
+
+  if (Context.ReloadRequired || (Context.PreferredImageAddress != Context.FileBase)) {
+    Context.ImageAddress = AllocatePages (EFI_SIZE_TO_PAGES (Context.ImageSize));
+  } else {
+    Context.ImageAddress = Context.FileBase;
+  }
+
+  //
+  // Load ELF into the required base
+  //
+  Status = LoadElfImage (&Context);
+  if (!EFI_ERROR (Status)) {
+    *ImageAddressArg       = (UINTN)Context.ImageAddress;
+    *UniversalPayloadEntry = Context.EntryPoint;
+    *ImageSizeArg          = Context.ImageSize;
+  }
+
+  return Status;
+}
+
+EFI_STATUS
+HandOffToPayload (
+  IN     PHYSICAL_ADDRESS      UniversalPayloadEntry,
+  IN     EFI_PEI_HOB_POINTERS  Hob
+  )
+{
+  UINTN  HobList;
+
+  HobList = (UINTN)(VOID *)Hob.Raw;
+  typedef VOID (EFIAPI *PayloadEntry)(UINTN);
+  ((PayloadEntry)(UINTN)UniversalPayloadEntry)(HobList);
+
+  CpuDeadLoop ();
+  return EFI_SUCCESS;
+}
+
+/**
+
+  Entry point to the C language phase of Shim Layer before UEFI payload.
+
+  @param[in]   BootloaderParameter    The starting address of bootloader parameter block.
+
+  @retval      It will not return if SUCCESS, and return error when passing bootloader parameter.
+
+**/
+EFI_STATUS
+EFIAPI
+_ModuleEntryPoint (
+  IN UINTN  BootloaderParameter
+  )
+{
+  EFI_STATUS            Status;
+  EFI_PEI_HOB_POINTERS  Hob;
+  PHYSICAL_ADDRESS      ImageAddress;
+  UINT64                ImageSize;
+  PHYSICAL_ADDRESS      UniversalPayloadEntry;
+
+  Status = PcdSet64S (PcdBootloaderParameter, BootloaderParameter);
+  ASSERT_EFI_ERROR (Status);
+
+  Status = ConvertCbmemToHob ();
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "ConvertCbmemToHob Status = %r\n", Status));
+    return Status;
+  }
+
+  Status = LoadPayload (&ImageAddress, &ImageSize, &UniversalPayloadEntry);
+  ASSERT_EFI_ERROR (Status);
+  BuildMemoryAllocationHob (ImageAddress, ImageSize, EfiBootServicesData);
+
+  Hob.HandoffInformationTable = (EFI_HOB_HANDOFF_INFO_TABLE *)GetFirstHob (EFI_HOB_TYPE_HANDOFF);
+  HandOffToPayload (UniversalPayloadEntry, Hob);
+
+  // Should not get here
+  CpuDeadLoop ();
+  return EFI_SUCCESS;
+}

--- a/UefiPayloadPkg/ShimLayer/ShimLayer.h
+++ b/UefiPayloadPkg/ShimLayer/ShimLayer.h
@@ -1,0 +1,232 @@
+/** @file
+
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __SHIMLAYER_H__
+#define __SHIMLAYER_H__
+
+#include <PiPei.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PeCoffLib.h>
+#include <Library/HobLib.h>
+#include <Library/PcdLib.h>
+#include <Guid/MemoryAllocationHob.h>
+#include <Library/IoLib.h>
+#include <Library/PeCoffLib.h>
+#include <Library/BlParseLib.h>
+#include <Library/PlatformSupportLib.h>
+#include <Library/UefiCpuLib.h>
+#include <IndustryStandard/Acpi.h>
+#include <IndustryStandard/MemoryMappedConfigurationSpaceAccessTable.h>
+#include <Guid/SerialPortInfoGuid.h>
+#include <Guid/MemoryMapInfoGuid.h>
+#include <Guid/AcpiBoardInfoGuid.h>
+#include <Guid/GraphicsInfoHob.h>
+#include <UniversalPayload/SmbiosTable.h>
+#include <UniversalPayload/AcpiTable.h>
+#include <UniversalPayload/UniversalPayload.h>
+#include <UniversalPayload/ExtraData.h>
+#include <UniversalPayload/SerialPortInfo.h>
+#include <Guid/PcdDataBaseSignatureGuid.h>
+#include <Coreboot.h>
+#include <Library/ElfLoaderLib.h>
+#include <Library/PciHostBridgeLib.h>
+#include <UniversalPayload/PciRootBridges.h>
+#include <Protocol/PciRootBridgeIo.h>
+#include <Protocol/PciHostBridgeResourceAllocation.h>
+#include "HobIioUds.h"
+
+#define SHIMLAYER_SIZE                    SIZE_1MB
+#define SHIMLAYER_REGION                  SIZE_16MB
+#define LEGACY_8259_MASK_REGISTER_MASTER  0x21
+#define LEGACY_8259_MASK_REGISTER_SLAVE   0xA1
+#define GET_OCCUPIED_SIZE(ActualSize, Alignment) \
+  ((ActualSize) + (((Alignment) - ((ActualSize) & ((Alignment) - 1))) & ((Alignment) - 1)))
+#define ALIGN_UP(x, a)  (((x)+(a - 1))&~(a-1))
+#define SWAP32(x) \
+  ((unsigned int)( \
+    (((unsigned int)(x) & 0x000000ffUL) << 24) | \
+    (((unsigned int)(x) & 0x0000ff00UL) <<  8) | \
+    (((unsigned int)(x) & 0x00ff0000UL) >>  8) | \
+    (((unsigned int)(x) & 0xff000000UL) >> 24)))
+
+#define E820_RAM        1
+#define E820_RESERVED   2
+#define E820_ACPI       3
+#define E820_NVS        4
+#define E820_UNUSABLE   5
+#define E820_DISABLED   6
+#define E820_PMEM       7
+#define E820_UNDEFINED  8
+
+RETURN_STATUS
+EFIAPI
+LzmaUefiDecompressGetInfo (
+  IN  CONST VOID  *Source,
+  IN  UINT32      SourceSize,
+  OUT UINT32      *DestinationSize,
+  OUT UINT32      *ScratchSize
+  );
+
+VOID *
+EFIAPI
+CreateHob (
+  IN  UINT16  HobType,
+  IN  UINT16  HobLength
+  );
+
+/**
+  Update the Stack Hob if the stack has been moved
+
+  @param  BaseAddress   The 64 bit physical address of the Stack.
+  @param  Length        The length of the stack in bytes.
+
+**/
+VOID
+EFIAPI
+UpdateStackHob (
+  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN UINT64                Length
+  );
+
+/**
+  Build a Handoff Information Table HOB
+
+  This function initialize a HOB region from EfiMemoryBegin to
+  EfiMemoryTop. And EfiFreeMemoryBottom and EfiFreeMemoryTop should
+  be inside the HOB region.
+
+  @param[in] EfiMemoryBottom       Total memory start address
+  @param[in] EfiMemoryTop          Total memory end address.
+  @param[in] EfiFreeMemoryBottom   Free memory start address
+  @param[in] EfiFreeMemoryTop      Free memory end address.
+
+  @return   The pointer to the handoff HOB table.
+
+**/
+EFI_HOB_HANDOFF_INFO_TABLE *
+EFIAPI
+HobConstructor (
+  IN VOID  *EfiMemoryBottom,
+  IN VOID  *EfiMemoryTop,
+  IN VOID  *EfiFreeMemoryBottom,
+  IN VOID  *EfiFreeMemoryTop
+  );
+
+/**
+  This function searchs a given section type within a valid FFS file.
+
+  @param  FileHeader            A pointer to the file header that contains the set of sections to
+                                be searched.
+  @param  SearchType            The value of the section type to search.
+  @param  SectionData           A pointer to the discovered section, if successful.
+
+  @retval EFI_SUCCESS           The section was found.
+  @retval EFI_NOT_FOUND         The section was not found.
+
+**/
+EFI_STATUS
+FileFindSection (
+  IN EFI_FFS_FILE_HEADER  *FileHeader,
+  IN EFI_SECTION_TYPE     SectionType,
+  OUT VOID                **SectionData
+  );
+
+/**
+  This function searchs a given file type with a given Guid within a valid FV.
+  If input Guid is NULL, will locate the first section having the given file type
+
+  @param FvHeader        A pointer to firmware volume header that contains the set of files
+                         to be searched.
+  @param FileType        File type to be searched.
+  @param Guid            Will ignore if it is NULL.
+  @param FileHeader      A pointer to the discovered file, if successful.
+
+  @retval EFI_SUCCESS    Successfully found FileType
+  @retval EFI_NOT_FOUND  File type can't be found.
+**/
+EFI_STATUS
+FvFindFileByTypeGuid (
+  IN  EFI_FIRMWARE_VOLUME_HEADER  *FvHeader,
+  IN  EFI_FV_FILETYPE             FileType,
+  IN  EFI_GUID                    *Guid           OPTIONAL,
+  OUT EFI_FFS_FILE_HEADER         **FileHeader
+  );
+
+RETURN_STATUS
+EFIAPI
+LzmaUefiDecompress (
+  IN CONST VOID  *Source,
+  IN UINTN       SourceSize,
+  IN OUT VOID    *Destination,
+  IN OUT VOID    *Scratch
+  );
+
+/**
+  Auto-generated function that calls the library constructors for all of the module's
+  dependent libraries.  This function must be called by the SEC Core once a stack has
+  been established.
+
+**/
+VOID
+EFIAPI
+ProcessLibraryConstructorList (
+  VOID
+  );
+
+/**
+  Find coreboot record with given Tag.
+
+  @param  Tag                The tag id to be found
+
+  @retval NULL              The Tag is not found.
+  @retval Others            The pointer to the record found.
+
+**/
+VOID *
+FindCbTag (
+  IN  UINT32  Tag
+  );
+
+/**
+  Find the given table with TableId from the given coreboot memory Root.
+
+  @param  Root               The coreboot memory table to be searched in
+  @param  TableId            Table id to be found
+  @param  MemTable           To save the base address of the memory table found
+  @param  MemTableSize       To save the size of memory table found
+
+  @retval RETURN_SUCCESS            Successfully find out the memory table.
+  @retval RETURN_INVALID_PARAMETER  Invalid input parameters.
+  @retval RETURN_NOT_FOUND          Failed to find the memory table.
+
+**/
+RETURN_STATUS
+FindCbMemTable (
+  IN  struct cbmem_root  *Root,
+  IN  UINT32             TableId,
+  OUT VOID               **MemTable,
+  OUT UINT32             *MemTableSize
+  );
+
+/**
+  Convert a packed value from cbuint64 to a UINT64 value.
+
+  @param  val      The pointer to packed data.
+
+  @return          the UNIT64 value after conversion.
+
+**/
+UINT64
+cb_unpack64 (
+  IN struct cbuint64  val
+  );
+
+#endif

--- a/UefiPayloadPkg/ShimLayer/ShimLayer.inf
+++ b/UefiPayloadPkg/ShimLayer/ShimLayer.inf
@@ -1,0 +1,66 @@
+## @file
+#  This module does the preload work for coreboot to load Universal Payload.
+#
+#  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = ShimLayer
+  FILE_GUID                      = 7B939555-9838-4D1E-BB63-A0F74E85C702
+  MODULE_TYPE                    = SEC
+  VERSION_STRING                 = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  UniversalPayload.o
+  ShimLayer.c
+  ShimLayer.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+  UefiPayloadPkg/UefiPayloadPkg.dec
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+  BaseLib
+  SerialPortLib
+  IoLib
+  BlParseLib
+  HobLib
+  UefiCpuLib
+  LzmaDecompressLib
+  ElfLoaderLib
+
+[Guids]
+  gEfiGraphicsInfoHobGuid
+  gEfiGraphicsDeviceInfoHobGuid
+  gUniversalPayloadSmbiosTableGuid
+  gUniversalPayloadAcpiTableGuid
+  gUniversalPayloadSerialPortInfoGuid
+  gUniversalPayloadExtraDataGuid
+  gUniversalPayloadPciRootBridgeInfoGuid
+  gUefiPayloadPkgTokenSpaceGuid
+
+[Pcd]
+  gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFdMemBase
+  gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFdMemSize
+  gUefiPayloadPkgTokenSpaceGuid.PcdBootloaderParameter
+  gUefiPayloadPkgTokenSpaceGuid.PcdSystemMemoryUefiRegionSize
+  gUefiPayloadPkgTokenSpaceGuid.PcdLinuxCommandLine
+
+[BuildOptions]
+  GCC:*_CLANGDWARF_*_DLINK2_FLAGS == -Wl,--defsym=PECOFF_HEADER_SIZE=0x800000 -Wl,--script=$(EDK_TOOLS_PATH)/Scripts/ClangBase.lds -O3 -fuse-ld=lld
+  GCC:*_GCC5_IA32_DLINK2_FLAGS == -Wl,--defsym=PECOFF_HEADER_SIZE=0x800000 -Wl,--script=$(EDK_TOOLS_PATH)/Scripts/GccBase.lds -Wno-error -no-pie
+  GCC:*_COREBOOT_IA32_DLINK2_FLAGS == -Wl,--defsym=PECOFF_HEADER_SIZE=0x800000 -Wl,--script=$(EDK_TOOLS_PATH)/Scripts/GccBase.lds -Wno-error -no-pie

--- a/UefiPayloadPkg/UefiPayloadPkg.dec
+++ b/UefiPayloadPkg/UefiPayloadPkg.dec
@@ -78,6 +78,7 @@ gUefiPayloadPkgTokenSpaceGuid.PcdMemoryTypeEfiACPIMemoryNVS|0x04|UINT32|0x100000
 gUefiPayloadPkgTokenSpaceGuid.PcdMemoryTypeEfiReservedMemoryType|0x04|UINT32|0x00000014
 gUefiPayloadPkgTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesData|0xC0|UINT32|0x00000015
 gUefiPayloadPkgTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesCode|0x80|UINT32|0x00000016
+gUefiPayloadPkgTokenSpaceGuid.PcdLinuxCommandLine|L""|VOID*|0x00000021
 
 # Size of the region used by UEFI in permanent memory
 gUefiPayloadPkgTokenSpaceGuid.PcdSystemMemoryUefiRegionSize|0x04000000|UINT32|0x00000017

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -56,6 +56,11 @@
   DEFINE   BOOTLOADER                 = SBL
 
   #
+  # SHIMLAYER: Build ShimLayer for coreboot
+  #
+  DEFINE SHIMLAYER                    = FALSE
+
+  #
   # CPU options
   #
   DEFINE MAX_LOGICAL_PROCESSORS       = 256
@@ -273,7 +278,7 @@
   DebugAgentLib|MdeModulePkg/Library/DebugAgentLibNull/DebugAgentLibNull.inf
 !endif
   PlatformSupportLib|UefiPayloadPkg/Library/PlatformSupportLibNull/PlatformSupportLibNull.inf
-!if $(UNIVERSAL_PAYLOAD) == FALSE
+!if $(UNIVERSAL_PAYLOAD) == FALSE || $(SHIMLAYER) == TRUE
   !if $(BOOTLOADER) == "COREBOOT"
     BlParseLib|UefiPayloadPkg/Library/CbParseLib/CbParseLib.inf
   !else
@@ -311,6 +316,8 @@
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
   DxeHobListLib|UefiPayloadPkg/Library/DxeHobListLibNull/DxeHobListLibNull.inf
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+  LzmaDecompressLib|MdeModulePkg/Library/LzmaCustomDecompressLib/LzmaCommonDecompressLib.inf
+  ElfLoaderLib|UefiPayloadPkg/PayloadLoaderPeim/ElfLoaderLib.inf
 
 [LibraryClasses.common.DXE_CORE]
   DxeHobListLib|UefiPayloadPkg/Library/DxeHobListLibNull/DxeHobListLibNull.inf
@@ -584,7 +591,18 @@
 ################################################################################
 
 !if "IA32" in "$(ARCH)"
+  !if $(BOOTLOADER) == "COREBOOT"
+  [PcdsFixedAtBuild]
+    gUefiPayloadPkgTokenSpaceGuid.PcdLinuxCommandLine|L"loglevel=7 earlyprintk=serial,ttyS0,115200 console=ttyS0,115200 disable_mtrr_cleanup"
+    gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFdMemBase|0x00800000
+    gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFdMemSize|0x00100000
+    gUefiPayloadPkgTokenSpaceGuid.PcdSystemMemoryUefiRegionSize|0x04000000
+  !endif
+
   [Components.IA32]
+  !if $(BOOTLOADER) == "COREBOOT" && $(SHIMLAYER) == TRUE
+    UefiPayloadPkg/ShimLayer/ShimLayer.inf
+  !endif
   !if $(UNIVERSAL_PAYLOAD) == TRUE
     UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.inf
   !else


### PR DESCRIPTION
[Issue Description]
Client Coreboot Universal Payload boot failed in DEBUG mode.

[Resolution]
Due to illegal base address of universal payload elf image,
it counted wrong shift offset.
Relocate it to an align base address.

Package/Module: UefiPayloadPkg/ShimLayer