### PR TITLE
UefiPayloadPkg: Preserve capsule results after scoped updates

### DIFF
--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmFlashRetry.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmFlashRetry.c
@@ -1,0 +1,189 @@
+/** @file
+  Internal retry helpers for SMMSTORE-backed firmware updates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/BaseMemoryLib.h>
+
+#include "FmpDeviceSmmFlashRetry.h"
+
+STATIC
+VOID
+StallAfterFailure (
+  IN CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN UINTN                      Attempt
+  )
+{
+  if (FlashIo->Stall != NULL) {
+    FlashIo->Stall (Attempt);
+  }
+}
+
+EFI_STATUS
+FmpDeviceFlashReadWithRetry (
+  IN     CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN     EFI_LBA                    Lba,
+  IN     UINTN                      Offset,
+  IN OUT UINTN                      *NumBytes,
+  OUT    UINT8                      *Buffer
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Attempt;
+  UINTN       RequestedBytes;
+  UINTN       ActualBytes;
+
+  if ((FlashIo == NULL) || (FlashIo->Read == NULL) || (NumBytes == NULL) || (Buffer == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  RequestedBytes = *NumBytes;
+  Status         = EFI_DEVICE_ERROR;
+  ActualBytes    = 0;
+
+  for (Attempt = 0; Attempt < FMP_DEVICE_SMM_FLASH_RETRY_COUNT; ++Attempt) {
+    ActualBytes = RequestedBytes;
+    Status      = FlashIo->Read (Lba, Offset, &ActualBytes, Buffer);
+    if (!EFI_ERROR (Status) && (ActualBytes == RequestedBytes)) {
+      *NumBytes = ActualBytes;
+      return EFI_SUCCESS;
+    }
+
+    *NumBytes = ActualBytes;
+    StallAfterFailure (FlashIo, Attempt);
+  }
+
+  return EFI_ERROR (Status) ? Status : EFI_DEVICE_ERROR;
+}
+
+EFI_STATUS
+FmpDeviceFlashEraseWithRetry (
+  IN CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN EFI_LBA                    Lba
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Attempt;
+
+  if ((FlashIo == NULL) || (FlashIo->Erase == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = EFI_DEVICE_ERROR;
+  for (Attempt = 0; Attempt < FMP_DEVICE_SMM_FLASH_RETRY_COUNT; ++Attempt) {
+    Status = FlashIo->Erase (Lba);
+    if (!EFI_ERROR (Status)) {
+      return EFI_SUCCESS;
+    }
+
+    StallAfterFailure (FlashIo, Attempt);
+  }
+
+  return Status;
+}
+
+EFI_STATUS
+FmpDeviceFlashWriteWithRetry (
+  IN     CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN     EFI_LBA                    Lba,
+  IN     UINTN                      Offset,
+  IN OUT UINTN                      *NumBytes,
+  IN     UINT8                      *Buffer
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Attempt;
+  UINTN       RequestedBytes;
+  UINTN       ActualBytes;
+
+  if ((FlashIo == NULL) || (FlashIo->Write == NULL) || (NumBytes == NULL) || (Buffer == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  RequestedBytes = *NumBytes;
+  Status         = EFI_DEVICE_ERROR;
+  ActualBytes    = 0;
+
+  for (Attempt = 0; Attempt < FMP_DEVICE_SMM_FLASH_RETRY_COUNT; ++Attempt) {
+    ActualBytes = RequestedBytes;
+    Status      = FlashIo->Write (Lba, Offset, &ActualBytes, Buffer);
+    if (!EFI_ERROR (Status) && (ActualBytes == RequestedBytes)) {
+      *NumBytes = ActualBytes;
+      return EFI_SUCCESS;
+    }
+
+    *NumBytes = ActualBytes;
+    StallAfterFailure (FlashIo, Attempt);
+  }
+
+  return EFI_ERROR (Status) ? Status : EFI_DEVICE_ERROR;
+}
+
+STATIC
+EFI_STATUS
+VerifyFlashWrite (
+  IN  CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN  EFI_LBA                    Lba,
+  IN  CONST UINT8                *Expected,
+  OUT UINT8                      *VerifyBuffer,
+  IN  UINTN                      BlockSize
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       NumBytes;
+
+  NumBytes = BlockSize;
+  Status   = FmpDeviceFlashReadWithRetry (FlashIo, Lba, 0, &NumBytes, VerifyBuffer);
+  if (EFI_ERROR (Status) || (NumBytes != BlockSize)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  return (CompareMem (VerifyBuffer, Expected, BlockSize) == 0) ? EFI_SUCCESS : EFI_VOLUME_CORRUPTED;
+}
+
+EFI_STATUS
+FmpDeviceFlashProgramWithRetry (
+  IN  CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN  EFI_LBA                    Lba,
+  IN  CONST UINT8                *Expected,
+  OUT UINT8                      *VerifyBuffer,
+  IN  UINTN                      BlockSize
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Attempt;
+  UINTN       NumBytes;
+
+  if ((FlashIo == NULL) || (FlashIo->Read == NULL) || (FlashIo->Write == NULL) ||
+      (FlashIo->Erase == NULL) || (Expected == NULL) || (VerifyBuffer == NULL) || (BlockSize == 0))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = EFI_DEVICE_ERROR;
+  for (Attempt = 0; Attempt < FMP_DEVICE_SMM_FLASH_RETRY_COUNT; ++Attempt) {
+    Status = FmpDeviceFlashEraseWithRetry (FlashIo, Lba);
+    if (EFI_ERROR (Status)) {
+      StallAfterFailure (FlashIo, Attempt);
+      continue;
+    }
+
+    NumBytes = BlockSize;
+    Status   = FmpDeviceFlashWriteWithRetry (FlashIo, Lba, 0, &NumBytes, (UINT8 *)Expected);
+    if (EFI_ERROR (Status) || (NumBytes != BlockSize)) {
+      Status = EFI_DEVICE_ERROR;
+      StallAfterFailure (FlashIo, Attempt);
+      continue;
+    }
+
+    Status = VerifyFlashWrite (FlashIo, Lba, Expected, VerifyBuffer, BlockSize);
+    if (!EFI_ERROR (Status)) {
+      return EFI_SUCCESS;
+    }
+
+    StallAfterFailure (FlashIo, Attempt);
+  }
+
+  return Status;
+}

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmFlashRetry.h
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmFlashRetry.h
@@ -1,0 +1,73 @@
+/** @file
+  Internal retry helpers for SMMSTORE-backed firmware updates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#pragma once
+
+#include <Uefi.h>
+
+#define FMP_DEVICE_SMM_FLASH_RETRY_COUNT  4
+
+typedef EFI_STATUS (*FMP_DEVICE_FLASH_READ)(
+  IN     EFI_LBA  Lba,
+  IN     UINTN    Offset,
+  IN OUT UINTN    *NumBytes,
+  OUT    UINT8    *Buffer
+  );
+
+typedef EFI_STATUS (*FMP_DEVICE_FLASH_WRITE)(
+  IN     EFI_LBA  Lba,
+  IN     UINTN    Offset,
+  IN OUT UINTN    *NumBytes,
+  IN     UINT8    *Buffer
+  );
+
+typedef EFI_STATUS (*FMP_DEVICE_FLASH_ERASE)(
+  IN EFI_LBA  Lba
+  );
+
+typedef VOID (*FMP_DEVICE_FLASH_STALL)(
+  IN UINTN  Attempt
+  );
+
+typedef struct {
+  FMP_DEVICE_FLASH_READ     Read;
+  FMP_DEVICE_FLASH_WRITE    Write;
+  FMP_DEVICE_FLASH_ERASE    Erase;
+  FMP_DEVICE_FLASH_STALL    Stall;
+} FMP_DEVICE_FLASH_IO;
+
+EFI_STATUS
+FmpDeviceFlashReadWithRetry (
+  IN     CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN     EFI_LBA                    Lba,
+  IN     UINTN                      Offset,
+  IN OUT UINTN                      *NumBytes,
+  OUT    UINT8                      *Buffer
+  );
+
+EFI_STATUS
+FmpDeviceFlashEraseWithRetry (
+  IN CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN EFI_LBA                    Lba
+  );
+
+EFI_STATUS
+FmpDeviceFlashWriteWithRetry (
+  IN     CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN     EFI_LBA                    Lba,
+  IN     UINTN                      Offset,
+  IN OUT UINTN                      *NumBytes,
+  IN     UINT8                      *Buffer
+  );
+
+EFI_STATUS
+FmpDeviceFlashProgramWithRetry (
+  IN  CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN  EFI_LBA                    Lba,
+  IN  CONST UINT8                *Expected,
+  OUT UINT8                      *VerifyBuffer,
+  IN  UINTN                      BlockSize
+  );

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
@@ -33,6 +33,8 @@
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Coreboot.h>
 
+#include "FmpDeviceSmmUpdatePolicy.h"
+
 //
 // Minimal FMAP parsing to locate and compare the flash map before updating.
 //
@@ -1927,6 +1929,9 @@ FmpDeviceSetImageWithStatus (
   VOID                         *FlashFmapBuffer;
   FMAP_HEADER                  *FlashFmapHeader;
   FMAP_AREA                    *FlashFmapAreas;
+  BOOLEAN                      VariableStorePreserved;
+  UINTN                        VariableStoreOffset;
+  UINTN                        VariableStoreSize;
 
   *LastAttemptStatus = LAST_ATTEMPT_STATUS_ERROR_UNSUCCESSFUL;
   BlockCount         = 0;
@@ -1968,9 +1973,12 @@ FmpDeviceSetImageWithStatus (
   FmapAreas          = NULL;
   FmapOffset         = 0;
   FmapLength         = 0;
-  FlashFmapBuffer    = NULL;
-  FlashFmapHeader    = NULL;
-  FlashFmapAreas     = NULL;
+  FlashFmapBuffer        = NULL;
+  FlashFmapHeader        = NULL;
+  FlashFmapAreas         = NULL;
+  VariableStorePreserved = FALSE;
+  VariableStoreOffset    = 0;
+  VariableStoreSize      = 0;
 
   Status = LocateRegionManifest (Image, ImageSize, &ManifestEntryCount, &ManifestEntries, &BaseImageSize);
   if (EFI_ERROR (Status)) {
@@ -2058,6 +2066,7 @@ FmpDeviceSetImageWithStatus (
     UINTN       CapsuleRegionSize;
     UINTN       FlashRegionOffset;
     UINTN       FlashRegionSize;
+    CONST CHAR8  SmmStoreRegionName[16] = "SMMSTORE";
 
     LayoutMismatch      = FALSE;
     MismatchIndex       = MAX_UINTN;
@@ -2077,6 +2086,23 @@ FmpDeviceSetImageWithStatus (
     if (EFI_ERROR (FlashFmapStatus)) {
       LayoutMismatch = TRUE;
       DEBUG ((DEBUG_WARN, "%a(): failed to load flash FMAP: %r\n", __func__, FlashFmapStatus));
+    } else {
+      Status = FindFmapRegion (
+                 FlashFmapHeader,
+                 FlashFmapAreas,
+                 FlashFmapHeader->AreaCount,
+                 SmmStoreRegionName,
+                 &VariableStoreOffset,
+                 &VariableStoreSize
+                 );
+      if (!EFI_ERROR (Status) && (VariableStoreSize != 0) &&
+          (VariableStoreOffset < BaseImageSize) &&
+          (VariableStoreSize <= (BaseImageSize - VariableStoreOffset)))
+      {
+        VariableStorePreserved = TRUE;
+      } else {
+        DEBUG ((DEBUG_WARN, "%a(): current SMMSTORE range is unavailable or invalid\n", __func__));
+      }
     }
 
     TotalSteps = 0;
@@ -2130,6 +2156,15 @@ FmpDeviceSetImageWithStatus (
             FlashRegionOffset = 0;
             FlashRegionSize   = 0;
           }
+        } else if (VariableStorePreserved &&
+                   FmpDeviceFlashRangesOverlap (
+                     FlashRegionOffset,
+                     FlashRegionSize,
+                     VariableStoreOffset,
+                     VariableStoreSize
+                     ))
+        {
+          VariableStorePreserved = FALSE;
         }
       }
 
@@ -2149,8 +2184,9 @@ FmpDeviceSetImageWithStatus (
       CHAR8        RegionName[17];
       CONST CHAR8  *BiosRegionSource;
 
-      UseManifest   = FALSE;
-      UseBiosRegion = FALSE;
+      UseManifest            = FALSE;
+      UseBiosRegion          = FALSE;
+      VariableStorePreserved = FALSE;
 
       if (MismatchIndex != MAX_UINTN) {
         CopyMem (RegionName, ManifestEntries[MismatchIndex].RegionName, 16);
@@ -2345,32 +2381,33 @@ FmpDeviceSetImageWithStatus (
   *LastAttemptStatus = LAST_ATTEMPT_STATUS_SUCCESS;
 
   //
-  // Updating the firmware on system flash overwrites SMMSTORE region which
-  // backs up EFI variables of the running firmware.  At this point both SMI
-  // handler from coreboot and variable services of EDK can be mistaken in
-  // their assumptions about the location, size and contents of the region.
-  // Accessing flash where SMMSTORE used to be can lead to unexpected results
-  // including corruption of the new image outside of its SMMSTORE.  Switch to
-  // the use of stubs for dealing with EFI variables that do nothing.
+  // A full-flash, BIOS-region, or overlapping manifest update can overwrite
+  // the SMMSTORE region that backs EFI variables.  In those cases, the running
+  // coreboot SMI handler and EDK variable services may have stale assumptions
+  // about the store, so replace the services with failure stubs.
   //
-  // New firmware will not report result of flashing in any way unless some
-  // kind of communication mechanism is implemented for this purpose.
+  // A manifest update may keep using variable services only when the live FMAP
+  // was read successfully, all selected regions matched the live layout, and
+  // none overlapped the live SMMSTORE range.  This lets FmpDxe persist final
+  // last-attempt state before the mandatory reset.
   //
   // If there was an error, it's unclear whether these stubs would be of any
   // help, so they are employed only on successful flashing.
   //
 
-  gRT->GetVariable         = GetVariableHook;
-  gRT->GetNextVariableName = GetNextVariableNameHook;
-  gRT->SetVariable         = SetVariableHook;
-  gRT->QueryVariableInfo   = QueryVariableInfoHook;
+  if (FmpDeviceShouldDisableVariableServices (UseManifest && VariableStorePreserved)) {
+    gRT->GetVariable         = GetVariableHook;
+    gRT->GetNextVariableName = GetNextVariableNameHook;
+    gRT->SetVariable         = SetVariableHook;
+    gRT->QueryVariableInfo   = QueryVariableInfoHook;
 
-  gRT->Hdr.CRC32 = 0;
-  gBS->CalculateCrc32 (
-         (UINT8 *)&gRT->Hdr,
-         gRT->Hdr.HeaderSize,
-         &gRT->Hdr.CRC32
-         );
+    gRT->Hdr.CRC32 = 0;
+    gBS->CalculateCrc32 (
+           (UINT8 *)&gRT->Hdr,
+           gRT->Hdr.HeaderSize,
+           &gRT->Hdr.CRC32
+           );
+  }
 
   return EFI_SUCCESS;
 

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
@@ -33,6 +33,7 @@
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Coreboot.h>
 
+#include "FmpDeviceSmmFlashRetry.h"
 #include "FmpDeviceSmmUpdatePolicy.h"
 
 //
@@ -67,7 +68,6 @@ typedef struct {
 //
 #define REGION_MANIFEST_SIGNATURE      SIGNATURE_32 ('R', 'M', 'A', 'P')
 #define REGION_MANIFEST_VERSION        1
-#define SMMSTORE_FLASH_RETRY_COUNT     4
 #define SMMSTORE_FLASH_RETRY_STALL_US  500
 #define INTEL_DESCRIPTOR_SIGNATURE     0x0ff0a55a
 #define INTEL_DESCRIPTOR_SIGNATURE_OFF 0x10
@@ -99,6 +99,46 @@ StallBetweenFlashAttempts (
 
 STATIC
 EFI_STATUS
+ReadAnyBlock (
+  IN     EFI_LBA  Lba,
+  IN     UINTN    Offset,
+  IN OUT UINTN    *NumBytes,
+  OUT    UINT8    *Buffer
+  )
+{
+  return SmmStoreLibReadAnyBlock (Lba, Offset, NumBytes, Buffer);
+}
+
+STATIC
+EFI_STATUS
+WriteAnyBlock (
+  IN     EFI_LBA  Lba,
+  IN     UINTN    Offset,
+  IN OUT UINTN    *NumBytes,
+  IN     UINT8    *Buffer
+  )
+{
+  return SmmStoreLibWriteAnyBlock (Lba, Offset, NumBytes, Buffer);
+}
+
+STATIC
+EFI_STATUS
+EraseAnyBlock (
+  IN EFI_LBA  Lba
+  )
+{
+  return SmmStoreLibEraseAnyBlock (Lba);
+}
+
+STATIC CONST FMP_DEVICE_FLASH_IO  mFlashIo = {
+  ReadAnyBlock,
+  WriteAnyBlock,
+  EraseAnyBlock,
+  StallBetweenFlashAttempts
+};
+
+STATIC
+EFI_STATUS
 ReadAnyBlockWithRetry (
   IN     EFI_LBA  Lba,
   IN     UINTN    Offset,
@@ -106,124 +146,7 @@ ReadAnyBlockWithRetry (
   OUT    VOID     *Buffer
   )
 {
-  EFI_STATUS  Status;
-  UINTN       Attempt;
-  UINTN       RequestedBytes;
-  UINTN       ActualBytes;
-
-  if ((NumBytes == NULL) || (Buffer == NULL)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  RequestedBytes = *NumBytes;
-  Status         = EFI_DEVICE_ERROR;
-  ActualBytes    = 0;
-
-  for (Attempt = 0; Attempt < SMMSTORE_FLASH_RETRY_COUNT; ++Attempt) {
-    ActualBytes = RequestedBytes;
-    Status      = SmmStoreLibReadAnyBlock (Lba, Offset, &ActualBytes, Buffer);
-    if (!EFI_ERROR (Status) && (ActualBytes == RequestedBytes)) {
-      *NumBytes = ActualBytes;
-      return EFI_SUCCESS;
-    }
-
-    *NumBytes = ActualBytes;
-    StallBetweenFlashAttempts (Attempt);
-  }
-
-  if (!EFI_ERROR (Status)) {
-    Status = EFI_DEVICE_ERROR;
-  }
-
-  return Status;
-}
-
-STATIC
-EFI_STATUS
-EraseAnyBlockWithRetry (
-  IN EFI_LBA  Lba
-  )
-{
-  EFI_STATUS  Status;
-  UINTN       Attempt;
-
-  Status = EFI_DEVICE_ERROR;
-  for (Attempt = 0; Attempt < SMMSTORE_FLASH_RETRY_COUNT; ++Attempt) {
-    Status = SmmStoreLibEraseAnyBlock (Lba);
-    if (!EFI_ERROR (Status)) {
-      return EFI_SUCCESS;
-    }
-
-    StallBetweenFlashAttempts (Attempt);
-  }
-
-  return Status;
-}
-
-STATIC
-EFI_STATUS
-WriteAnyBlockWithRetry (
-  IN     EFI_LBA  Lba,
-  IN     UINTN    Offset,
-  IN OUT UINTN    *NumBytes,
-  IN     VOID     *Buffer
-  )
-{
-  EFI_STATUS  Status;
-  UINTN       Attempt;
-  UINTN       RequestedBytes;
-  UINTN       ActualBytes;
-
-  if ((NumBytes == NULL) || (Buffer == NULL)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  RequestedBytes = *NumBytes;
-  Status         = EFI_DEVICE_ERROR;
-  ActualBytes    = 0;
-
-  for (Attempt = 0; Attempt < SMMSTORE_FLASH_RETRY_COUNT; ++Attempt) {
-    ActualBytes = RequestedBytes;
-    Status      = SmmStoreLibWriteAnyBlock (Lba, Offset, &ActualBytes, Buffer);
-    if (!EFI_ERROR (Status) && (ActualBytes == RequestedBytes)) {
-      *NumBytes = ActualBytes;
-      return EFI_SUCCESS;
-    }
-
-    *NumBytes = ActualBytes;
-    StallBetweenFlashAttempts (Attempt);
-  }
-
-  if (!EFI_ERROR (Status)) {
-    Status = EFI_DEVICE_ERROR;
-  }
-
-  return Status;
-}
-
-STATIC
-EFI_STATUS
-VerifyAnyBlockWrite (
-  IN  EFI_LBA      Lba,
-  IN  CONST UINT8  *Expected,
-  OUT UINT8        *VerifyBuffer,
-  IN  UINTN        BlockSize
-  )
-{
-  EFI_STATUS  Status;
-  UINTN       NumBytes;
-
-  if ((Expected == NULL) || (VerifyBuffer == NULL) || (BlockSize == 0)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  NumBytes = BlockSize;
-  Status   = ReadAnyBlockWithRetry (Lba, 0, &NumBytes, VerifyBuffer);
-  if (EFI_ERROR (Status) || (NumBytes != BlockSize)) {
-    return EFI_DEVICE_ERROR;
-  }
-
-  return (CompareMem (VerifyBuffer, Expected, BlockSize) == 0) ? EFI_SUCCESS : EFI_VOLUME_CORRUPTED;
+  return FmpDeviceFlashReadWithRetry (&mFlashIo, Lba, Offset, NumBytes, Buffer);
 }
 
 STATIC
@@ -235,39 +158,7 @@ ProgramAnyBlockWithRetry (
   IN  UINTN        BlockSize
   )
 {
-  EFI_STATUS  Status;
-  UINTN       Attempt;
-  UINTN       NumBytes;
-
-  if ((Expected == NULL) || (VerifyBuffer == NULL) || (BlockSize == 0)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  Status = EFI_DEVICE_ERROR;
-  for (Attempt = 0; Attempt < SMMSTORE_FLASH_RETRY_COUNT; ++Attempt) {
-    Status = EraseAnyBlockWithRetry (Lba);
-    if (EFI_ERROR (Status)) {
-      StallBetweenFlashAttempts (Attempt);
-      continue;
-    }
-
-    NumBytes = BlockSize;
-    Status   = WriteAnyBlockWithRetry (Lba, 0, &NumBytes, (VOID *)Expected);
-    if (EFI_ERROR (Status) || (NumBytes != BlockSize)) {
-      Status = EFI_DEVICE_ERROR;
-      StallBetweenFlashAttempts (Attempt);
-      continue;
-    }
-
-    Status = VerifyAnyBlockWrite (Lba, Expected, VerifyBuffer, BlockSize);
-    if (!EFI_ERROR (Status)) {
-      return EFI_SUCCESS;
-    }
-
-    StallBetweenFlashAttempts (Attempt);
-  }
-
-  return Status;
+  return FmpDeviceFlashProgramWithRetry (&mFlashIo, Lba, Expected, VerifyBuffer, BlockSize);
 }
 
 STATIC

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
@@ -21,6 +21,8 @@
 
 [Sources]
   FmpDeviceSmmLib.c
+  FmpDeviceSmmUpdatePolicy.c
+  FmpDeviceSmmUpdatePolicy.h
 
 [LibraryClasses]
   BaseMemoryLib

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
@@ -21,6 +21,8 @@
 
 [Sources]
   FmpDeviceSmmLib.c
+  FmpDeviceSmmFlashRetry.c
+  FmpDeviceSmmFlashRetry.h
   FmpDeviceSmmUpdatePolicy.c
   FmpDeviceSmmUpdatePolicy.h
 

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTest.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTest.c
@@ -1,0 +1,139 @@
+/** @file
+  Unit tests for SMMSTORE-backed firmware update policy.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <Uefi.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UnitTestLib.h>
+
+#include "FmpDeviceSmmUpdatePolicy.h"
+
+#define UNIT_TEST_APP_NAME     "FmpDeviceSmmLib Unit Tests"
+#define UNIT_TEST_APP_VERSION  "1.0"
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+PreservedStoreKeepsVariableServices (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_ASSERT_FALSE (FmpDeviceShouldDisableVariableServices (TRUE));
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+UnprovenStoreDisablesVariableServices (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_ASSERT_TRUE (FmpDeviceShouldDisableVariableServices (FALSE));
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+OverlappingRangesAreDetected (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_ASSERT_TRUE (FmpDeviceFlashRangesOverlap (0x1000, 0x2000, 0x2000, 0x1000));
+  UT_ASSERT_TRUE (FmpDeviceFlashRangesOverlap (0x2000, 0x1000, 0x1000, 0x2000));
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+AdjacentRangesDoNotOverlap (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_ASSERT_FALSE (FmpDeviceFlashRangesOverlap (0x1000, 0x1000, 0x2000, 0x1000));
+  UT_ASSERT_FALSE (FmpDeviceFlashRangesOverlap (0x2000, 0x1000, 0x1000, 0x1000));
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+MalformedRangesFailClosed (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_ASSERT_TRUE (FmpDeviceFlashRangesOverlap (0x1000, 0, 0x2000, 0x1000));
+  UT_ASSERT_TRUE (FmpDeviceFlashRangesOverlap (MAX_UINTN - 1, 2, 0x2000, 0x1000));
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+EFI_STATUS
+EFIAPI
+UnitTestingEntry (
+  VOID
+  )
+{
+  EFI_STATUS                  Status;
+  UNIT_TEST_FRAMEWORK_HANDLE  Framework;
+  UNIT_TEST_SUITE_HANDLE      PolicyTests;
+
+  Framework = NULL;
+  DEBUG ((DEBUG_INFO, "%a v%a\n", UNIT_TEST_APP_NAME, UNIT_TEST_APP_VERSION));
+
+  Status = InitUnitTestFramework (
+             &Framework,
+             UNIT_TEST_APP_NAME,
+             gEfiCallerBaseName,
+             UNIT_TEST_APP_VERSION
+             );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = CreateUnitTestSuite (
+             &PolicyTests,
+             Framework,
+             "SMMSTORE update policy",
+             "FmpDeviceSmmLib.Policy",
+             NULL,
+             NULL
+             );
+  if (EFI_ERROR (Status)) {
+    FreeUnitTestFramework (Framework);
+    return Status;
+  }
+
+  AddTestCase (PolicyTests, "Preserved store keeps variable services", "PreservedStore", PreservedStoreKeepsVariableServices, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Unproven store disables variable services", "UnprovenStore", UnprovenStoreDisablesVariableServices, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Overlapping ranges are detected", "Overlap", OverlappingRangesAreDetected, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Adjacent ranges do not overlap", "Adjacent", AdjacentRangesDoNotOverlap, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Malformed ranges fail closed", "Malformed", MalformedRangesFailClosed, NULL, NULL, NULL);
+
+  Status = RunAllTestSuites (Framework);
+  FreeUnitTestFramework (Framework);
+  return Status;
+}
+
+#define FmpDeviceSmmLibUnitTestMain  main
+
+INT32
+FmpDeviceSmmLibUnitTestMain (
+  IN INT32  Argc,
+  IN CHAR8  *Argv[]
+  )
+{
+  return EFI_ERROR (UnitTestingEntry ()) ? 1 : 0;
+}

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTest.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTest.c
@@ -12,14 +12,139 @@
 #include <cmocka.h>
 
 #include <Uefi.h>
+#include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/UnitTestLib.h>
 
+#include "FmpDeviceSmmFlashRetry.h"
 #include "FmpDeviceSmmUpdatePolicy.h"
 
 #define UNIT_TEST_APP_NAME     "FmpDeviceSmmLib Unit Tests"
 #define UNIT_TEST_APP_VERSION  "1.0"
+#define TEST_BLOCK_SIZE        16
+
+typedef struct {
+  UINTN      ReadFailures;
+  UINTN      WriteFailures;
+  UINTN      EraseFailures;
+  UINTN      CorruptReads;
+  BOOLEAN    ShortWrites;
+  UINTN      ReadCalls;
+  UINTN      WriteCalls;
+  UINTN      EraseCalls;
+  UINTN      StallCalls;
+  UINT8      Storage[TEST_BLOCK_SIZE];
+} FLASH_IO_TEST_CONTEXT;
+
+STATIC FLASH_IO_TEST_CONTEXT  mFlashContext;
+
+STATIC
+BOOLEAN
+ConsumeFailure (
+  IN OUT UINTN  *Failures
+  )
+{
+  if (*Failures == 0) {
+    return FALSE;
+  }
+
+  (*Failures)--;
+  return TRUE;
+}
+
+STATIC
+EFI_STATUS
+TestFlashRead (
+  IN     EFI_LBA  Lba,
+  IN     UINTN    Offset,
+  IN OUT UINTN    *NumBytes,
+  OUT    UINT8    *Buffer
+  )
+{
+  mFlashContext.ReadCalls++;
+  if (ConsumeFailure (&mFlashContext.ReadFailures)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  if ((Offset > sizeof (mFlashContext.Storage)) || (*NumBytes > (sizeof (mFlashContext.Storage) - Offset))) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  CopyMem (Buffer, mFlashContext.Storage + Offset, *NumBytes);
+  if (ConsumeFailure (&mFlashContext.CorruptReads) && (*NumBytes > 0)) {
+    Buffer[0] ^= 0xff;
+  }
+
+  return EFI_SUCCESS;
+}
+
+STATIC
+EFI_STATUS
+TestFlashWrite (
+  IN     EFI_LBA  Lba,
+  IN     UINTN    Offset,
+  IN OUT UINTN    *NumBytes,
+  IN     UINT8    *Buffer
+  )
+{
+  mFlashContext.WriteCalls++;
+  if (ConsumeFailure (&mFlashContext.WriteFailures)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  if (mFlashContext.ShortWrites && (*NumBytes > 0)) {
+    (*NumBytes)--;
+    return EFI_SUCCESS;
+  }
+
+  if ((Offset > sizeof (mFlashContext.Storage)) || (*NumBytes > (sizeof (mFlashContext.Storage) - Offset))) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  CopyMem (mFlashContext.Storage + Offset, Buffer, *NumBytes);
+  return EFI_SUCCESS;
+}
+
+STATIC
+EFI_STATUS
+TestFlashErase (
+  IN EFI_LBA  Lba
+  )
+{
+  mFlashContext.EraseCalls++;
+  if (ConsumeFailure (&mFlashContext.EraseFailures)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  SetMem (mFlashContext.Storage, sizeof (mFlashContext.Storage), 0xff);
+  return EFI_SUCCESS;
+}
+
+STATIC
+VOID
+TestFlashStall (
+  IN UINTN  Attempt
+  )
+{
+  mFlashContext.StallCalls++;
+}
+
+STATIC CONST FMP_DEVICE_FLASH_IO  mTestFlashIo = {
+  TestFlashRead,
+  TestFlashWrite,
+  TestFlashErase,
+  TestFlashStall
+};
+
+STATIC
+VOID
+ResetFlashContext (
+  VOID
+  )
+{
+  ZeroMem (&mFlashContext, sizeof (mFlashContext));
+}
 
 STATIC
 UNIT_TEST_STATUS
@@ -80,6 +205,119 @@ MalformedRangesFailClosed (
 }
 
 STATIC
+UNIT_TEST_STATUS
+EFIAPI
+TransientFlashErrorsRecover (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+  UINT8       Expected[TEST_BLOCK_SIZE];
+  UINT8       VerifyBuffer[TEST_BLOCK_SIZE];
+
+  ResetFlashContext ();
+  SetMem (Expected, sizeof (Expected), 0x5a);
+  mFlashContext.EraseFailures = 1;
+  mFlashContext.WriteFailures = 1;
+  mFlashContext.CorruptReads  = 1;
+
+  Status = FmpDeviceFlashProgramWithRetry (&mTestFlashIo, 0, Expected, VerifyBuffer, sizeof (Expected));
+
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+  UT_ASSERT_EQUAL (mFlashContext.EraseCalls, 3);
+  UT_ASSERT_EQUAL (mFlashContext.WriteCalls, 3);
+  UT_ASSERT_EQUAL (mFlashContext.ReadCalls, 2);
+  UT_ASSERT_MEM_EQUAL (mFlashContext.Storage, Expected, sizeof (Expected));
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+ReadErrorsExhaustRetryLimit (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       NumBytes;
+  UINT8       Buffer[TEST_BLOCK_SIZE];
+
+  ResetFlashContext ();
+  mFlashContext.ReadFailures = FMP_DEVICE_SMM_FLASH_RETRY_COUNT;
+  NumBytes                   = sizeof (Buffer);
+
+  Status = FmpDeviceFlashReadWithRetry (&mTestFlashIo, 0, 0, &NumBytes, Buffer);
+
+  UT_ASSERT_EQUAL (Status, EFI_DEVICE_ERROR);
+  UT_ASSERT_EQUAL (mFlashContext.ReadCalls, FMP_DEVICE_SMM_FLASH_RETRY_COUNT);
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+EraseErrorsExhaustRetryLimit (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+
+  ResetFlashContext ();
+  mFlashContext.EraseFailures = FMP_DEVICE_SMM_FLASH_RETRY_COUNT;
+
+  Status = FmpDeviceFlashEraseWithRetry (&mTestFlashIo, 0);
+
+  UT_ASSERT_EQUAL (Status, EFI_DEVICE_ERROR);
+  UT_ASSERT_EQUAL (mFlashContext.EraseCalls, FMP_DEVICE_SMM_FLASH_RETRY_COUNT);
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+WriteErrorsExhaustRetryLimit (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       NumBytes;
+  UINT8       Buffer[TEST_BLOCK_SIZE];
+
+  ResetFlashContext ();
+  mFlashContext.WriteFailures = FMP_DEVICE_SMM_FLASH_RETRY_COUNT;
+  NumBytes                    = sizeof (Buffer);
+
+  Status = FmpDeviceFlashWriteWithRetry (&mTestFlashIo, 0, 0, &NumBytes, Buffer);
+
+  UT_ASSERT_EQUAL (Status, EFI_DEVICE_ERROR);
+  UT_ASSERT_EQUAL (mFlashContext.WriteCalls, FMP_DEVICE_SMM_FLASH_RETRY_COUNT);
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+ShortWritesExhaustRetryLimit (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       NumBytes;
+  UINT8       Buffer[TEST_BLOCK_SIZE];
+
+  ResetFlashContext ();
+  mFlashContext.ShortWrites = TRUE;
+  NumBytes                  = sizeof (Buffer);
+
+  Status = FmpDeviceFlashWriteWithRetry (&mTestFlashIo, 0, 0, &NumBytes, Buffer);
+
+  UT_ASSERT_EQUAL (Status, EFI_DEVICE_ERROR);
+  UT_ASSERT_EQUAL (mFlashContext.WriteCalls, FMP_DEVICE_SMM_FLASH_RETRY_COUNT);
+  UT_ASSERT_EQUAL (NumBytes, sizeof (Buffer) - 1);
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
 EFI_STATUS
 EFIAPI
 UnitTestingEntry (
@@ -121,6 +359,11 @@ UnitTestingEntry (
   AddTestCase (PolicyTests, "Overlapping ranges are detected", "Overlap", OverlappingRangesAreDetected, NULL, NULL, NULL);
   AddTestCase (PolicyTests, "Adjacent ranges do not overlap", "Adjacent", AdjacentRangesDoNotOverlap, NULL, NULL, NULL);
   AddTestCase (PolicyTests, "Malformed ranges fail closed", "Malformed", MalformedRangesFailClosed, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Transient flash errors recover", "TransientIo", TransientFlashErrorsRecover, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Read errors exhaust retry limit", "ReadError", ReadErrorsExhaustRetryLimit, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Erase errors exhaust retry limit", "EraseError", EraseErrorsExhaustRetryLimit, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Write errors exhaust retry limit", "WriteError", WriteErrorsExhaustRetryLimit, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Short writes exhaust retry limit", "ShortWrite", ShortWritesExhaustRetryLimit, NULL, NULL, NULL);
 
   Status = RunAllTestSuites (Framework);
   FreeUnitTestFramework (Framework);

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTestHost.inf
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTestHost.inf
@@ -1,0 +1,27 @@
+## @file
+# Host unit tests for SMMSTORE-backed firmware update policy.
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION         = 0x00010017
+  BASE_NAME           = FmpDeviceSmmLibUnitTest
+  FILE_GUID           = 2A8F905F-D9DF-4292-99BB-1D5122260ADE
+  VERSION_STRING      = 1.0
+  MODULE_TYPE         = HOST_APPLICATION
+
+[Sources]
+  FmpDeviceSmmLibUnitTest.c
+  FmpDeviceSmmUpdatePolicy.c
+  FmpDeviceSmmUpdatePolicy.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UefiPayloadPkg/UefiPayloadPkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  DebugLib
+  MemoryAllocationLib
+  UnitTestLib

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTestHost.inf
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTestHost.inf
@@ -13,6 +13,8 @@
 
 [Sources]
   FmpDeviceSmmLibUnitTest.c
+  FmpDeviceSmmFlashRetry.c
+  FmpDeviceSmmFlashRetry.h
   FmpDeviceSmmUpdatePolicy.c
   FmpDeviceSmmUpdatePolicy.h
 
@@ -22,6 +24,7 @@
   UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
 
 [LibraryClasses]
+  BaseMemoryLib
   DebugLib
   MemoryAllocationLib
   UnitTestLib

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmUpdatePolicy.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmUpdatePolicy.c
@@ -1,0 +1,34 @@
+/** @file
+  Internal policy helpers for SMMSTORE-backed firmware updates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "FmpDeviceSmmUpdatePolicy.h"
+
+BOOLEAN
+FmpDeviceFlashRangesOverlap (
+  IN UINTN  FirstOffset,
+  IN UINTN  FirstSize,
+  IN UINTN  SecondOffset,
+  IN UINTN  SecondSize
+  )
+{
+  if ((FirstSize == 0) || (SecondSize == 0) ||
+      (FirstOffset > (MAX_UINTN - FirstSize)) ||
+      (SecondOffset > (MAX_UINTN - SecondSize)))
+  {
+    return TRUE;
+  }
+
+  return (FirstOffset < (SecondOffset + SecondSize)) &&
+         (SecondOffset < (FirstOffset + FirstSize));
+}
+
+BOOLEAN
+FmpDeviceShouldDisableVariableServices (
+  IN BOOLEAN  VariableStorePreserved
+  )
+{
+  return !VariableStorePreserved;
+}

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmUpdatePolicy.h
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmUpdatePolicy.h
@@ -1,0 +1,22 @@
+/** @file
+  Internal policy helpers for SMMSTORE-backed firmware updates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#pragma once
+
+#include <Base.h>
+
+BOOLEAN
+FmpDeviceFlashRangesOverlap (
+  IN UINTN  FirstOffset,
+  IN UINTN  FirstSize,
+  IN UINTN  SecondOffset,
+  IN UINTN  SecondSize
+  );
+
+BOOLEAN
+FmpDeviceShouldDisableVariableServices (
+  IN BOOLEAN  VariableStorePreserved
+  );

--- a/UefiPayloadPkg/Test/UefiPayloadPkgHostTest.dsc
+++ b/UefiPayloadPkg/Test/UefiPayloadPkgHostTest.dsc
@@ -1,0 +1,20 @@
+## @file
+# UefiPayloadPkg host-based unit tests.
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  PLATFORM_NAME           = UefiPayloadPkgHostTest
+  PLATFORM_GUID           = 890D9F9C-1D24-45FE-B88B-8E3D06CF5795
+  PLATFORM_VERSION        = 0.1
+  DSC_SPECIFICATION       = 0x00010005
+  OUTPUT_DIRECTORY        = Build/UefiPayloadPkg/HostTest
+  SUPPORTED_ARCHITECTURES = IA32|X64
+  BUILD_TARGETS           = NOOPT
+  SKUID_IDENTIFIER        = DEFAULT
+
+!include UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+
+[Components]
+  UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTestHost.inf


### PR DESCRIPTION
## Summary

Keep runtime variable services available after a successful RMAP-scoped update when the live FMAP proves that SMMSTORE was not touched. Full-flash, BIOS fallback, malformed, mismatched, out-of-range and overlapping layouts continue to disable variable access.

The second commit extracts the existing retry loop behind internal I/O callbacks and adds deterministic coverage for transient and terminal read, erase, write, short-write and readback failures.

## Why

The writer previously disabled runtime variable services after every successful update. That prevented FmpDxe from recording the final capsule result even when the selected regions left SMMSTORE intact.

## Test

- UefiPayloadPkg host tests: 10/10 passed under ASan
- RELEASE GCC X64 FmpDxe build with SMMSTORE capsule support
- EDK2 PatchCheck