### PR TITLE
MdeModulePkg: Preserve capsule RAM across staging reset

### DIFF
--- a/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
+++ b/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
@@ -24,6 +24,7 @@
 
 [Components]
   MdeModulePkg/Library/DxeResetSystemLib/UnitTest/MockUefiRuntimeServicesTableLib.inf
+  MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleResetPolicyUnitTestHost.inf
 
   #
   # Build MdeModulePkg HOST_APPLICATION Tests

--- a/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleResetPolicy.c
+++ b/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleResetPolicy.c
@@ -1,0 +1,15 @@
+/** @file
+  Capsule staging reset policy.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "CapsuleResetPolicy.h"
+
+EFI_RESET_TYPE
+GetCapsuleResetType (
+  IN BOOLEAN  PersistAcrossReset
+  )
+{
+  return PersistAcrossReset ? EfiResetWarm : EfiResetCold;
+}

--- a/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleResetPolicy.h
+++ b/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleResetPolicy.h
@@ -1,0 +1,14 @@
+/** @file
+  Capsule staging reset policy.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#pragma once
+
+#include <Uefi.h>
+
+EFI_RESET_TYPE
+GetCapsuleResetType (
+  IN BOOLEAN  PersistAcrossReset
+  );

--- a/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleResetPolicyUnitTest.c
+++ b/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleResetPolicyUnitTest.c
@@ -1,0 +1,100 @@
+/** @file
+  Unit tests for capsule staging reset policy.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <Uefi.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UnitTestLib.h>
+
+#include "CapsuleResetPolicy.h"
+
+#define UNIT_TEST_APP_NAME     "Capsule Reset Policy Unit Tests"
+#define UNIT_TEST_APP_VERSION  "1.0"
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+PersistedCapsulesUseWarmReset (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_ASSERT_EQUAL (GetCapsuleResetType (TRUE), EfiResetWarm);
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+ImmediateCapsulesKeepColdReset (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_ASSERT_EQUAL (GetCapsuleResetType (FALSE), EfiResetCold);
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+EFI_STATUS
+EFIAPI
+UnitTestingEntry (
+  VOID
+  )
+{
+  EFI_STATUS                  Status;
+  UNIT_TEST_FRAMEWORK_HANDLE  Framework;
+  UNIT_TEST_SUITE_HANDLE      PolicyTests;
+
+  Framework = NULL;
+  DEBUG ((DEBUG_INFO, "%a v%a\n", UNIT_TEST_APP_NAME, UNIT_TEST_APP_VERSION));
+
+  Status = InitUnitTestFramework (
+             &Framework,
+             UNIT_TEST_APP_NAME,
+             gEfiCallerBaseName,
+             UNIT_TEST_APP_VERSION
+             );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = CreateUnitTestSuite (
+             &PolicyTests,
+             Framework,
+             "Capsule reset policy",
+             "CapsuleRuntimeDxe.ResetPolicy",
+             NULL,
+             NULL
+             );
+  if (EFI_ERROR (Status)) {
+    FreeUnitTestFramework (Framework);
+    return Status;
+  }
+
+  AddTestCase (PolicyTests, "Persisted capsules use warm reset", "PersistedWarm", PersistedCapsulesUseWarmReset, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Immediate capsules keep cold reset", "ImmediateCold", ImmediateCapsulesKeepColdReset, NULL, NULL, NULL);
+
+  Status = RunAllTestSuites (Framework);
+  FreeUnitTestFramework (Framework);
+  return Status;
+}
+
+#define CapsuleResetPolicyUnitTestMain  main
+
+INT32
+CapsuleResetPolicyUnitTestMain (
+  IN INT32  Argc,
+  IN CHAR8  *Argv[]
+  )
+{
+  return EFI_ERROR (UnitTestingEntry ()) ? 1 : 0;
+}

--- a/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleResetPolicyUnitTestHost.inf
+++ b/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleResetPolicyUnitTestHost.inf
@@ -1,0 +1,27 @@
+## @file
+# Host unit tests for capsule staging reset policy.
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION         = 0x00010017
+  BASE_NAME           = CapsuleResetPolicyUnitTest
+  FILE_GUID           = 9D0CAEC9-AE85-4D68-BE96-03284D8348E6
+  VERSION_STRING      = 1.0
+  MODULE_TYPE         = HOST_APPLICATION
+
+[Sources]
+  CapsuleResetPolicyUnitTest.c
+  CapsuleResetPolicy.c
+  CapsuleResetPolicy.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  DebugLib
+  MemoryAllocationLib
+  UnitTestLib

--- a/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf
@@ -29,6 +29,8 @@
 [Sources]
   CapsuleService.c
   CapsuleService.h
+  CapsuleResetPolicy.c
+  CapsuleResetPolicy.h
 
 [Sources.Ia32, Sources.EBC, Sources.AARCH64, Sources.RISCV64, Sources.LOONGARCH64]
   SaveLongModeContext.c

--- a/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleService.c
+++ b/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleService.c
@@ -10,6 +10,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #include "CapsuleService.h"
+#include "CapsuleResetPolicy.h"
 
 //
 // Handle for the installation of Capsule Architecture Protocol.
@@ -224,7 +225,7 @@ UpdateCapsule (
       // will initiate a reset of the platform which is compatible with the passed-in capsule request and will
       // not return back to the caller.
       //
-      EfiResetSystem (EfiResetCold, EFI_SUCCESS, 0, NULL);
+      EfiResetSystem (GetCapsuleResetType (TRUE), EFI_SUCCESS, 0, NULL);
     }
   }
 
@@ -350,13 +351,13 @@ QueryCapsuleCapabilities (
       return EFI_UNSUPPORTED;
     }
 
-    *ResetType         = EfiResetCold;
+    *ResetType         = GetCapsuleResetType (TRUE);
     *MaxiumCapsuleSize = (UINT64)mMaxSizePopulateCapsule;
   } else {
     //
     // For non-reset capsule image.
     //
-    *ResetType         = EfiResetCold;
+    *ResetType         = GetCapsuleResetType (FALSE);
     *MaxiumCapsuleSize = (UINT64)mMaxSizeNonPopulateCapsule;
   }
 


### PR DESCRIPTION
## Summary

Use a warm reset after staging a persisted capsule so coreboot can consume the RAM-backed scatter/gather list. Immediate capsules and the independent post-application reset continue to use a cold reset.

## Why

The Star Labs staging path used a cold reset, which destroys the RAM metadata required by coreboot's capsule handoff. This differs from upstream EDK2 and Dasharo behavior.

## Test

- MdeModulePkg host tests: 2/2 passed under ASan
- RELEASE GCC X64 CapsuleRuntimeDxe build
- DEBUG GCC IA32/X64 UefiPayloadPkg build
- QEMU q35: warm reset preserves and discovers the staged capsule; cold-reset baseline corrupts the descriptor
- EDK2 PatchCheck